### PR TITLE
ci: add govulncheck, Dependabot, and auto-assign

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      go-dependencies:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - area:ci

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,24 @@
+name: Auto-assign
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    name: Assign PR author to linked issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ github.event.pull_request.body }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "$BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | while read -r num; do
+            gh issue edit "$num" --repo "$REPO" --add-assignee "$AUTHOR"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,16 @@ jobs:
 
       - name: Test
         run: go test -tags integration -timeout 120s ./...
+
+  vulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
+        with:
+          repo-checkout: false


### PR DESCRIPTION
## Summary

- **govulncheck**: new `vulncheck` job in CI using `golang/govulncheck-action@v1` — fails the build if any Go dependency has a known CVE
- **Dependabot**: weekly updates for `gomod` and `github-actions` ecosystems, minor/patch updates grouped into a single PR each to reduce noise; major bumps still get individual PRs
- **Auto-assign**: new `auto-assign.yml` workflow that assigns the PR author to any issue linked via `Closes #N`, `Fixes #N`, or `Resolves #N` in the PR body

## Test plan

- [ ] CI lint/unit/integration/vulncheck jobs all green on this PR
- [ ] After merge, open a test PR with `Closes #<issue>` in the body and verify the author is assigned to the issue automatically

Closes #18