### PR TITLE
ci: run tests with -race and print coverage summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Test
-        run: go test ./...
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out
 
   integration:
     name: Integration Tests
@@ -51,7 +54,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test
-        run: go test -tags integration -timeout 120s ./...
+        run: go test -race -tags integration -timeout 120s ./...
 
   vulncheck:
     name: Vulnerability Check


### PR DESCRIPTION
## Summary

- Unit and integration tests now run with `-race` to catch data races, particularly relevant for the transactional upsert in `handlePatchAccessibility`
- Unit test job generates a `coverage.out` profile and prints a per-function summary via `go tool cover -func` in the job log

No coverage threshold or external service — keeping it simple while the project is early-stage.

## Test plan

- [ ] All CI jobs green
- [ ] Unit Tests job log shows coverage summary per function

Closes #19