### PR TITLE
feat: add /healthz and /readyz endpoints

### DIFF
--- a/cmd/api/integration_test.go
+++ b/cmd/api/integration_test.go
@@ -559,3 +559,16 @@ func TestHandleGetPlace_NoParentReturnsRawData(t *testing.T) {
 		t.Error("component should not be inherited for place with no parent")
 	}
 }
+
+func TestHandleReadyz_DBReachable(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	newTestServer().handleReadyz(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != `{"status":"ok"}` {
+		t.Errorf("body = %q, want {\"status\":\"ok\"}", w.Body.String())
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -67,6 +68,8 @@ func main() {
 	srv := &Server{db: gormDB, engine: &a11y.Engine{}}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", srv.handleHealthz)
+	mux.HandleFunc("GET /readyz", srv.handleReadyz)
 	mux.HandleFunc("GET /places", srv.handleGetPlaces)
 	mux.HandleFunc("GET /places/{id}", srv.handleGetPlace)
 	mux.HandleFunc("POST /places", srv.handlePostPlace)
@@ -261,6 +264,24 @@ func (s *Server) handlePatchAccessibility(w http.ResponseWriter, r *http.Request
 	}
 
 	jsonResponse(w, result, http.StatusOK)
+}
+
+// handleHealthz is a liveness probe: returns 200 as long as the process is running.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	jsonResponse(w, map[string]string{"status": "ok"}, http.StatusOK)
+}
+
+// handleReadyz is a readiness probe: returns 200 when the DB is reachable, 503 otherwise.
+func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+
+	sqlDB, err := s.db.DB()
+	if err != nil || sqlDB.PingContext(ctx) != nil {
+		jsonResponse(w, map[string]string{"status": "degraded"}, http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, map[string]string{"status": "ok"}, http.StatusOK)
 }
 
 // conflictError builds the 422 response body from a slice of detected conflicts.

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -236,6 +236,19 @@ func TestGetEnv(t *testing.T) {
 	}
 }
 
+func TestHandleHealthz(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	(&Server{}).handleHealthz(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if w.Body.String() != `{"status":"ok"}` {
+		t.Errorf("body = %q, want {\"status\":\"ok\"}", w.Body.String())
+	}
+}
+
 func TestHandlePostPlace_InvalidJSON(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/places", bytes.NewBufferString("{bad json"))
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- `GET /healthz` — liveness probe, always 200 if the process is up
- `GET /readyz` — readiness probe, pings the DB with a 2s timeout; 503 if unreachable
- Both return `{"status":"ok"}` / `{"status":"degraded"}` as JSON
- Unit test for `/healthz`, integration test for `/readyz` with a live DB

## Test plan

- [ ] CI passes (unit + integration)
- [ ] `GET /healthz` returns 200 `{"status":"ok"}`
- [ ] `GET /readyz` returns 200 when DB is up

Closes #7