### PR TITLE
feat: structured input validation across all endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,10 @@ Two active binaries under `cmd/`:
 
 **Data flow:**
 1. Client submits accessibility data via API
-2. `a11y.Engine` runs synchronously: computes `AuditFlags` from component properties, then checks for conflicts between submitted `OverallStatus` and those flags
-3. Conflicts return HTTP 422 with a list of contradictions — caller must reconcile
-4. Clean data is persisted as-is
+2. `validation` runs structural checks (required fields, enum membership, numeric bounds, UUID format, query-param combos); failures return HTTP 400 with a field-level error list
+3. `a11y.Engine` runs synchronously: computes `AuditFlags` from component properties, then checks for conflicts between submitted `OverallStatus` and those flags
+4. Conflicts return HTTP 422 with a list of contradictions — caller must reconcile
+5. Clean data is persisted as-is
 
 The API is a pure data layer. It stores and returns accessibility facts; it never computes whether a place is "accessible". Clients apply their own relevance logic per user profile.
 
@@ -47,6 +48,8 @@ The API is a pure data layer. It stores and returns accessibility facts; it neve
 - `Engine.WithAuditFlags()` — populates `AuditFlags` on each component deterministically from property values (e.g. entrance width < 0.8m → `"narrow width (0.8m required)"`)
 - `Engine.DetectConflicts()` — returns conflicts where a component is marked `StatusAccessible` but carries a hard contradiction flag (step-with-no-ramp, explicitly-not-wheelchair-accessible, no-disabled-spaces); informational threshold flags never trigger this
 - `Engine.ComputeEffectiveProfile()` — resolves inherited components from parent places
+
+**`internal/validation`** — Structural request validation. Pure functions over `pkg/models` types: `Place`, `AccessibilityProfile`, `PlaceID`, `PlacesQuery`. Runs before the a11y engine; returns `[]FieldError` for handlers to render as a 400 response.
 
 **`internal/geo`** — PostGIS spatial queries (`ST_DWithin`, `ST_MakeEnvelope`)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	"github.com/InWheelOrg/inwheel-server/internal/a11y"
 	"github.com/InWheelOrg/inwheel-server/internal/db"
 	"github.com/InWheelOrg/inwheel-server/internal/geo"
+	"github.com/InWheelOrg/inwheel-server/internal/validation"
 	"github.com/InWheelOrg/inwheel-server/pkg/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -99,36 +99,30 @@ func main() {
 // If 'min_lng', 'min_lat', 'max_lng', and 'max_lat' are provided, it performs a bounding box search.
 //
 // If no spatial parameters are present, it defaults to returning the most recently updated 100 places.
-// It returns a 400 Bad Request if coordinate parameters are present but malformed.
+// Returns 400 with a structured field-error list if any query param is malformed or out of bounds.
 func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	lngStr := q.Get("lng")
-	latStr := q.Get("lat")
-	radiusStr := q.Get("radius")
+	if errs := validation.PlacesQuery(q); len(errs) > 0 {
+		jsonResponse(w, validationError(errs), http.StatusBadRequest)
+		return
+	}
 
 	var places []models.Place
 	var err error
 
-	if lngStr != "" && latStr != "" && radiusStr != "" {
-		lng, ok1 := parseCoord(w, lngStr, "longitude")
-		lat, ok2 := parseCoord(w, latStr, "latitude")
-		radius, ok3 := parseCoord(w, radiusStr, "radius")
-
-		if !ok1 || !ok2 || !ok3 {
-			return
-		}
+	switch {
+	case q.Get("lng") != "":
+		lng, _ := strconv.ParseFloat(q.Get("lng"), 64)
+		lat, _ := strconv.ParseFloat(q.Get("lat"), 64)
+		radius, _ := strconv.ParseFloat(q.Get("radius"), 64)
 		places, err = geo.FindNearbyPlaces(s.db, lng, lat, radius)
-	} else if q.Get("min_lng") != "" {
-		minLng, ok1 := parseCoord(w, q.Get("min_lng"), "min_lng")
-		minLat, ok2 := parseCoord(w, q.Get("min_lat"), "min_lat")
-		maxLng, ok3 := parseCoord(w, q.Get("max_lng"), "max_lng")
-		maxLat, ok4 := parseCoord(w, q.Get("max_lat"), "max_lat")
-
-		if !ok1 || !ok2 || !ok3 || !ok4 {
-			return
-		}
+	case q.Get("min_lng") != "":
+		minLng, _ := strconv.ParseFloat(q.Get("min_lng"), 64)
+		minLat, _ := strconv.ParseFloat(q.Get("min_lat"), 64)
+		maxLng, _ := strconv.ParseFloat(q.Get("max_lng"), 64)
+		maxLat, _ := strconv.ParseFloat(q.Get("max_lat"), 64)
 		places, err = geo.FindPlacesInBoundingBox(s.db, minLng, minLat, maxLng, maxLat)
-	} else {
+	default:
 		err = s.db.Preload("Accessibility").Order("updated_at DESC").Limit(100).Find(&places).Error
 	}
 
@@ -147,6 +141,11 @@ func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 // Endpoint: GET /places/{id}
 func (s *Server) handleGetPlace(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if errs := validation.PlaceID(id); len(errs) > 0 {
+		jsonResponse(w, validationError(errs), http.StatusBadRequest)
+		return
+	}
+
 	var place models.Place
 	if err := s.db.Preload("Accessibility").First(&place, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -182,6 +181,11 @@ func (s *Server) handlePostPlace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if errs := validation.Place(&place); len(errs) > 0 {
+		jsonResponse(w, validationError(errs), http.StatusBadRequest)
+		return
+	}
+
 	if place.Accessibility != nil {
 		place.Accessibility.UpdatedAt = time.Now()
 		s.engine.WithAuditFlags(place.Accessibility)
@@ -204,6 +208,10 @@ func (s *Server) handlePostPlace(w http.ResponseWriter, r *http.Request) {
 // Endpoint: PATCH /places/{id}/accessibility
 func (s *Server) handlePatchAccessibility(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if errs := validation.PlaceID(id); len(errs) > 0 {
+		jsonResponse(w, validationError(errs), http.StatusBadRequest)
+		return
+	}
 
 	// Limit the request body to 1 MB (1 << 20 bytes)
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
@@ -211,6 +219,11 @@ func (s *Server) handlePatchAccessibility(w http.ResponseWriter, r *http.Request
 	var input models.AccessibilityProfile
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		http.Error(w, "Payload too large or invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if errs := validation.AccessibilityProfile(&input); len(errs) > 0 {
+		jsonResponse(w, validationError(errs), http.StatusBadRequest)
 		return
 	}
 
@@ -284,6 +297,17 @@ func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]string{"status": "ok"}, http.StatusOK)
 }
 
+// validationError builds the 400 response body from a slice of structural-validation errors.
+func validationError(errs []validation.FieldError) any {
+	return struct {
+		Error  string                   `json:"error"`
+		Fields []validation.FieldError  `json:"fields"`
+	}{
+		Error:  "validation failed",
+		Fields: errs,
+	}
+}
+
 // conflictError builds the 422 response body from a slice of detected conflicts.
 func conflictError(conflicts []a11y.Conflict) any {
 	type conflictItem struct {
@@ -318,19 +342,6 @@ func jsonResponse(w http.ResponseWriter, data any, code int) {
 	if _, err := w.Write(payload); err != nil {
 		slog.Error("Error writing JSON response", "error", err)
 	}
-}
-
-// parseCoord attempts to parse a string into a float64.
-// If parsing fails, it writes an HTTP 400 error to the provided ResponseWriter
-// and returns (0, false). The caller must check the boolean return value
-// before proceeding with the parsed result.
-func parseCoord(w http.ResponseWriter, val string, name string) (float64, bool) {
-	f, err := strconv.ParseFloat(val, 64)
-	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
-		http.Error(w, "Invalid "+name, http.StatusBadRequest)
-		return 0, false
-	}
-	return f, true
 }
 
 // getEnv is a helper to read an environment variable or return a fallback value.

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,128 +59,6 @@ func TestJsonResponse(t *testing.T) {
 				t.Errorf("Header = %q, want %q", w.Header().Get("Content-Type"), tt.wantHeader)
 			}
 			if w.Body.String() != tt.wantBody {
-				t.Errorf("Body = %q, want %q", w.Body.String(), tt.wantBody)
-			}
-		})
-	}
-}
-
-func TestParseCoord(t *testing.T) {
-	tests := []struct {
-		name       string
-		input      string
-		coordType  string
-		wantVal    float64
-		wantOk     bool
-		wantStatus int
-		wantBody   string
-	}{
-		{
-			name:       "valid coordinate",
-			input:      "13.405",
-			coordType:  "longitude",
-			wantVal:    13.405,
-			wantOk:     true,
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "high precision",
-			input:      "13.405123456789",
-			coordType:  "longitude",
-			wantVal:    13.405123456789,
-			wantOk:     true,
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "zero value",
-			input:      "0",
-			coordType:  "radius",
-			wantVal:    0,
-			wantOk:     true,
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "invalid coordinate",
-			input:      "invalid",
-			coordType:  "latitude",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid latitude\n",
-		},
-		{
-			name:       "empty string",
-			input:      "",
-			coordType:  "radius",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid radius\n",
-		},
-		{
-			name:       "whitespace",
-			input:      " 13.405 ",
-			coordType:  "longitude",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid longitude\n",
-		},
-		{
-			name:       "NaN input",
-			input:      "NaN",
-			coordType:  "longitude",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid longitude\n",
-		},
-		{
-			name:       "Inf input",
-			input:      "Inf",
-			coordType:  "latitude",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid latitude\n",
-		},
-		{
-			name:       "Injection attempt",
-			input:      "13.4; DROP TABLE places",
-			coordType:  "latitude",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid latitude\n",
-		},
-		{
-			name:       "Overflow input",
-			input:      "1e309",
-			coordType:  "radius",
-			wantVal:    0,
-			wantOk:     false,
-			wantStatus: http.StatusBadRequest,
-			wantBody:   "Invalid radius\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			w := httptest.NewRecorder()
-			val, ok := parseCoord(w, tt.input, tt.coordType)
-
-			if ok != tt.wantOk {
-				t.Errorf("parseCoord() ok = %v, want %v", ok, tt.wantOk)
-			}
-			if val != tt.wantVal {
-				t.Errorf("parseCoord() val = %f, want %f", val, tt.wantVal)
-			}
-			if w.Code != tt.wantStatus {
-				t.Errorf("Status Code = %d, want %d", w.Code, tt.wantStatus)
-			}
-			if tt.wantBody != "" && w.Body.String() != tt.wantBody {
 				t.Errorf("Body = %q, want %q", w.Body.String(), tt.wantBody)
 			}
 		})
@@ -259,8 +138,11 @@ func TestHandlePostPlace_InvalidJSON(t *testing.T) {
 	}
 }
 
+const validUUID = "11111111-1111-1111-1111-111111111111"
+
 func TestHandlePatchAccessibility_InvalidJSON(t *testing.T) {
-	r := httptest.NewRequest(http.MethodPatch, "/places/some-id/accessibility", bytes.NewBufferString("{bad json"))
+	r := httptest.NewRequest(http.MethodPatch, "/places/"+validUUID+"/accessibility", bytes.NewBufferString("{bad json"))
+	r.SetPathValue("id", validUUID)
 	w := httptest.NewRecorder()
 	(&Server{}).handlePatchAccessibility(w, r)
 
@@ -287,4 +169,128 @@ func TestHandleGetPlaces_InvalidBoundingBoxCoord(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
+}
+
+func decodeValidationError(t *testing.T, body []byte) (string, []map[string]string) {
+	t.Helper()
+	var resp struct {
+		Error  string              `json:"error"`
+		Fields []map[string]string `json:"fields"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode validation error response: %v", err)
+	}
+	return resp.Error, resp.Fields
+}
+
+func TestHandlePostPlace_400OnLatOutOfBounds(t *testing.T) {
+	body := `{"name":"X","lat":91,"lng":13.4,"category":"cafe"}`
+	r := httptest.NewRequest(http.MethodPost, "/places", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	(&Server{}).handlePostPlace(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	msg, fields := decodeValidationError(t, w.Body.Bytes())
+	if msg != "validation failed" {
+		t.Errorf("error = %q, want validation failed", msg)
+	}
+	if len(fields) == 0 || fields[0]["field"] != "lat" {
+		t.Errorf("expected field error on lat, got %+v", fields)
+	}
+}
+
+func TestHandlePostPlace_400OnMissingName(t *testing.T) {
+	body := `{"lat":52.5,"lng":13.4,"category":"cafe"}`
+	r := httptest.NewRequest(http.MethodPost, "/places", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	(&Server{}).handlePostPlace(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	_, fields := decodeValidationError(t, w.Body.Bytes())
+	if !hasField(fields, "name") {
+		t.Errorf("expected field error on name, got %+v", fields)
+	}
+}
+
+func TestHandlePostPlace_400OnInvalidCategory(t *testing.T) {
+	body := `{"name":"X","lat":52.5,"lng":13.4,"category":"spaceship"}`
+	r := httptest.NewRequest(http.MethodPost, "/places", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	(&Server{}).handlePostPlace(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	_, fields := decodeValidationError(t, w.Body.Bytes())
+	if !hasField(fields, "category") {
+		t.Errorf("expected field error on category, got %+v", fields)
+	}
+}
+
+func TestHandleGetPlace_400OnInvalidUUID(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/places/not-a-uuid", nil)
+	r.SetPathValue("id", "not-a-uuid")
+	w := httptest.NewRecorder()
+	(&Server{}).handleGetPlace(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	_, fields := decodeValidationError(t, w.Body.Bytes())
+	if !hasField(fields, "id") {
+		t.Errorf("expected field error on id, got %+v", fields)
+	}
+}
+
+func TestHandleGetPlaces_400OnRadiusNonPositive(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/places?lng=13.4&lat=52.5&radius=-5", nil)
+	w := httptest.NewRecorder()
+	(&Server{}).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	_, fields := decodeValidationError(t, w.Body.Bytes())
+	if !hasField(fields, "radius") {
+		t.Errorf("expected field error on radius, got %+v", fields)
+	}
+}
+
+func TestHandleGetPlaces_400OnPartialBoundingBox(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/places?min_lng=13.0&min_lat=52.0&max_lng=14.0", nil)
+	w := httptest.NewRecorder()
+	(&Server{}).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandlePatchAccessibility_400OnInvalidStatus(t *testing.T) {
+	body := `{"overall_status":"not-a-status"}`
+	r := httptest.NewRequest(http.MethodPatch, "/places/"+validUUID+"/accessibility", bytes.NewBufferString(body))
+	r.SetPathValue("id", validUUID)
+	w := httptest.NewRecorder()
+	(&Server{}).handlePatchAccessibility(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	_, fields := decodeValidationError(t, w.Body.Bytes())
+	if !hasField(fields, "overall_status") {
+		t.Errorf("expected field error on overall_status, got %+v", fields)
+	}
+}
+
+func hasField(fields []map[string]string, field string) bool {
+	for _, f := range fields {
+		if f["field"] == field {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -1,0 +1,358 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Package validation enforces structural and bounds constraints on incoming API
+// requests. Runs before the a11y engine: malformed input → 400 with a field-level
+// error list; the engine handles business consistency (audit flags, conflicts → 422).
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/InWheelOrg/inwheel-server/pkg/models"
+)
+
+// FieldError describes a single rejected field. Matches the JSON shape returned
+// in 400 validation responses.
+type FieldError struct {
+	Field  string `json:"field"`
+	Reason string `json:"reason"`
+}
+
+const (
+	maxNameLength      = 256
+	maxSourceLength    = 64
+	maxTagEntries      = 50
+	maxTagKeyLength    = 64
+	maxTagValueLength  = 256
+	maxMetadataEntries = 50
+	maxMetadataBytes   = 4 * 1024
+
+	maxDimensionMeters    = 10.0
+	maxStepHeightMeters   = 1.0
+	maxParkingCount       = 10000
+	maxRadiusMeters       = 50000.0
+	worldLatMin           = -90.0
+	worldLatMax           = 90.0
+	worldLngMin           = -180.0
+	worldLngMax           = 180.0
+)
+
+var (
+	uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+	validCategories = map[models.Category]bool{
+		models.CategoryMall: true, models.CategoryAirport: true,
+		models.CategoryTrainStation: true, models.CategoryRestaurant: true,
+		models.CategoryCafe: true, models.CategoryShop: true,
+		models.CategoryToilet: true, models.CategoryParking: true,
+		models.CategoryEntrance: true, models.CategoryOther: true,
+	}
+	validOSMTypes = map[models.OSMType]bool{
+		models.OSMNode: true, models.OSMWay: true, models.OSMRelation: true,
+	}
+	validRanks = map[models.Rank]bool{
+		models.RankLandmark: true, models.RankEstablishment: true, models.RankFeature: true,
+	}
+	validStatuses = map[models.A11yStatus]bool{
+		models.StatusAccessible: true, models.StatusLimited: true,
+		models.StatusInaccessible: true, models.StatusUnknown: true,
+	}
+	validComponentTypes = map[models.A11yComponentType]bool{
+		models.ComponentEntrance: true, models.ComponentRestroom: true,
+		models.ComponentParking: true, models.ComponentElevator: true,
+		models.ComponentOther: true,
+	}
+)
+
+// Place validates a *models.Place for structural correctness. Returns nil if valid.
+func Place(p *models.Place) []FieldError {
+	if p == nil {
+		return []FieldError{{Field: "", Reason: "place is required"}}
+	}
+
+	var errs []FieldError
+
+	if strings.TrimSpace(p.Name) == "" {
+		errs = append(errs, FieldError{Field: "name", Reason: "is required"})
+	} else if len(p.Name) > maxNameLength {
+		errs = append(errs, FieldError{Field: "name", Reason: fmt.Sprintf("must be ≤ %d characters", maxNameLength)})
+	}
+
+	errs = append(errs, validateLat("lat", p.Lat)...)
+	errs = append(errs, validateLng("lng", p.Lng)...)
+
+	if p.Category == "" {
+		errs = append(errs, FieldError{Field: "category", Reason: "is required"})
+	} else if !validCategories[p.Category] {
+		errs = append(errs, FieldError{Field: "category", Reason: fmt.Sprintf("%q is not a valid category", string(p.Category))})
+	}
+
+	if p.Rank != 0 && !validRanks[p.Rank] {
+		errs = append(errs, FieldError{Field: "rank", Reason: "must be 1, 2, or 3"})
+	}
+
+	if p.OSMID != 0 && p.OSMID < 0 {
+		errs = append(errs, FieldError{Field: "osm_id", Reason: "must be positive"})
+	}
+
+	if p.OSMType != "" && !validOSMTypes[p.OSMType] {
+		errs = append(errs, FieldError{Field: "osm_type", Reason: fmt.Sprintf("%q is not a valid OSM type", string(p.OSMType))})
+	}
+
+	if len(p.Source) > maxSourceLength {
+		errs = append(errs, FieldError{Field: "source", Reason: fmt.Sprintf("must be ≤ %d characters", maxSourceLength)})
+	}
+
+	if p.ParentID != nil && !uuidRegex.MatchString(*p.ParentID) {
+		errs = append(errs, FieldError{Field: "parent_id", Reason: "must be a valid UUID"})
+	}
+
+	errs = append(errs, validateTags(p.Tags)...)
+
+	if p.Accessibility != nil {
+		for _, e := range AccessibilityProfile(p.Accessibility) {
+			e.Field = "accessibility." + e.Field
+			errs = append(errs, e)
+		}
+	}
+
+	return errs
+}
+
+// AccessibilityProfile validates a *models.AccessibilityProfile (used standalone for
+// PATCH /places/{id}/accessibility, and recursively from Place).
+func AccessibilityProfile(prof *models.AccessibilityProfile) []FieldError {
+	if prof == nil {
+		return nil
+	}
+	var errs []FieldError
+
+	if prof.OverallStatus == "" {
+		errs = append(errs, FieldError{Field: "overall_status", Reason: "is required"})
+	} else if !validStatuses[prof.OverallStatus] {
+		errs = append(errs, FieldError{Field: "overall_status", Reason: fmt.Sprintf("%q is not a valid status", string(prof.OverallStatus))})
+	}
+
+	for i, comp := range prof.Components {
+		prefix := fmt.Sprintf("components[%d]", i)
+		for _, e := range validateComponent(comp) {
+			e.Field = prefix + "." + e.Field
+			errs = append(errs, e)
+		}
+	}
+
+	return errs
+}
+
+// PlaceID validates a path-param ID is a well-formed UUID.
+func PlaceID(id string) []FieldError {
+	if !uuidRegex.MatchString(id) {
+		return []FieldError{{Field: "id", Reason: "must be a valid UUID"}}
+	}
+	return nil
+}
+
+// PlacesQuery validates the query string of GET /places.
+func PlacesQuery(q url.Values) []FieldError {
+	circular := []string{q.Get("lng"), q.Get("lat"), q.Get("radius")}
+	bbox := []string{q.Get("min_lng"), q.Get("min_lat"), q.Get("max_lng"), q.Get("max_lat")}
+
+	circularPresent := nonEmptyCount(circular)
+	bboxPresent := nonEmptyCount(bbox)
+
+	if circularPresent != 0 && circularPresent != len(circular) {
+		return []FieldError{{Field: "query", Reason: "lng, lat, and radius must all be provided together"}}
+	}
+	if bboxPresent != 0 && bboxPresent != len(bbox) {
+		return []FieldError{{Field: "query", Reason: "min_lng, min_lat, max_lng, and max_lat must all be provided together"}}
+	}
+	if circularPresent > 0 && bboxPresent > 0 {
+		return []FieldError{{Field: "query", Reason: "circular and bounding-box parameters are mutually exclusive"}}
+	}
+
+	var errs []FieldError
+
+	if circularPresent == len(circular) {
+		lng, e1 := parseFloat("lng", q.Get("lng"))
+		lat, e2 := parseFloat("lat", q.Get("lat"))
+		radius, e3 := parseFloat("radius", q.Get("radius"))
+		errs = appendIfErr(errs, e1, e2, e3)
+		if e1 == nil {
+			errs = append(errs, validateLng("lng", lng)...)
+		}
+		if e2 == nil {
+			errs = append(errs, validateLat("lat", lat)...)
+		}
+		if e3 == nil {
+			if radius <= 0 || radius > maxRadiusMeters {
+				errs = append(errs, FieldError{Field: "radius", Reason: fmt.Sprintf("must be between 0 (exclusive) and %g", maxRadiusMeters)})
+			}
+		}
+	}
+
+	if bboxPresent == len(bbox) {
+		minLng, e1 := parseFloat("min_lng", q.Get("min_lng"))
+		minLat, e2 := parseFloat("min_lat", q.Get("min_lat"))
+		maxLng, e3 := parseFloat("max_lng", q.Get("max_lng"))
+		maxLat, e4 := parseFloat("max_lat", q.Get("max_lat"))
+		errs = appendIfErr(errs, e1, e2, e3, e4)
+		if e1 == nil {
+			errs = append(errs, validateLng("min_lng", minLng)...)
+		}
+		if e3 == nil {
+			errs = append(errs, validateLng("max_lng", maxLng)...)
+		}
+		if e2 == nil {
+			errs = append(errs, validateLat("min_lat", minLat)...)
+		}
+		if e4 == nil {
+			errs = append(errs, validateLat("max_lat", maxLat)...)
+		}
+		if e1 == nil && e3 == nil && minLng >= maxLng {
+			errs = append(errs, FieldError{Field: "min_lng", Reason: "must be less than max_lng"})
+		}
+		if e2 == nil && e4 == nil && minLat >= maxLat {
+			errs = append(errs, FieldError{Field: "min_lat", Reason: "must be less than max_lat"})
+		}
+	}
+
+	return errs
+}
+
+func validateComponent(comp models.A11yComponent) []FieldError {
+	var errs []FieldError
+
+	if comp.Type == "" {
+		errs = append(errs, FieldError{Field: "type", Reason: "is required"})
+	} else if !validComponentTypes[comp.Type] {
+		errs = append(errs, FieldError{Field: "type", Reason: fmt.Sprintf("%q is not a valid component type", string(comp.Type))})
+	}
+
+	if comp.OverallStatus != "" && !validStatuses[comp.OverallStatus] {
+		errs = append(errs, FieldError{Field: "overall_status", Reason: fmt.Sprintf("%q is not a valid status", string(comp.OverallStatus))})
+	}
+
+	if comp.Entrance != nil {
+		errs = append(errs, validateBoundedFloat("entrance.width", comp.Entrance.Width, 0, maxDimensionMeters)...)
+		errs = append(errs, validateBoundedFloat("entrance.step_height", comp.Entrance.StepHeight, 0, maxStepHeightMeters)...)
+	}
+	if comp.Restroom != nil {
+		errs = append(errs, validateBoundedFloat("restroom.door_width", comp.Restroom.DoorWidth, 0, maxDimensionMeters)...)
+	}
+	if comp.Elevator != nil {
+		errs = append(errs, validateBoundedFloat("elevator.width", comp.Elevator.Width, 0, maxDimensionMeters)...)
+		errs = append(errs, validateBoundedFloat("elevator.depth", comp.Elevator.Depth, 0, maxDimensionMeters)...)
+	}
+	if comp.Parking != nil && comp.Parking.Count != nil {
+		c := *comp.Parking.Count
+		if c < 0 || c > maxParkingCount {
+			errs = append(errs, FieldError{Field: "parking.count", Reason: fmt.Sprintf("must be between 0 and %d", maxParkingCount)})
+		}
+	}
+
+	errs = append(errs, validateMetadata(comp.Metadata)...)
+
+	return errs
+}
+
+func validateBoundedFloat(field string, v *float64, min, max float64) []FieldError {
+	if v == nil {
+		return nil
+	}
+	if math.IsNaN(*v) || math.IsInf(*v, 0) {
+		return []FieldError{{Field: field, Reason: "must be a finite number"}}
+	}
+	if *v < min || *v > max {
+		return []FieldError{{Field: field, Reason: fmt.Sprintf("must be between %g and %g", min, max)}}
+	}
+	return nil
+}
+
+func validateLat(field string, v float64) []FieldError {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return []FieldError{{Field: field, Reason: "must be a finite number"}}
+	}
+	if v < worldLatMin || v > worldLatMax {
+		return []FieldError{{Field: field, Reason: "must be between -90 and 90"}}
+	}
+	return nil
+}
+
+func validateLng(field string, v float64) []FieldError {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return []FieldError{{Field: field, Reason: "must be a finite number"}}
+	}
+	if v < worldLngMin || v > worldLngMax {
+		return []FieldError{{Field: field, Reason: "must be between -180 and 180"}}
+	}
+	return nil
+}
+
+func validateTags(tags models.PlaceTags) []FieldError {
+	if len(tags) > maxTagEntries {
+		return []FieldError{{Field: "tags", Reason: fmt.Sprintf("must contain ≤ %d entries", maxTagEntries)}}
+	}
+	var errs []FieldError
+	for k, v := range tags {
+		if len(k) > maxTagKeyLength {
+			errs = append(errs, FieldError{Field: "tags", Reason: fmt.Sprintf("key %q exceeds %d characters", k, maxTagKeyLength)})
+		}
+		if len(v) > maxTagValueLength {
+			errs = append(errs, FieldError{Field: "tags", Reason: fmt.Sprintf("value for key %q exceeds %d characters", k, maxTagValueLength)})
+		}
+	}
+	return errs
+}
+
+func validateMetadata(md map[string]any) []FieldError {
+	if len(md) > maxMetadataEntries {
+		return []FieldError{{Field: "metadata", Reason: fmt.Sprintf("must contain ≤ %d entries", maxMetadataEntries)}}
+	}
+	if len(md) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(md)
+	if err != nil {
+		return []FieldError{{Field: "metadata", Reason: "must be JSON-serialisable"}}
+	}
+	if len(b) > maxMetadataBytes {
+		return []FieldError{{Field: "metadata", Reason: fmt.Sprintf("serialised size exceeds %d bytes", maxMetadataBytes)}}
+	}
+	return nil
+}
+
+func parseFloat(field, raw string) (float64, *FieldError) {
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, &FieldError{Field: field, Reason: "must be a finite number"}
+	}
+	return v, nil
+}
+
+func nonEmptyCount(ss []string) int {
+	n := 0
+	for _, s := range ss {
+		if s != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func appendIfErr(dst []FieldError, errs ...*FieldError) []FieldError {
+	for _, e := range errs {
+		if e != nil {
+			dst = append(dst, *e)
+		}
+	}
+	return dst
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -76,7 +76,7 @@ var (
 // Place validates a *models.Place for structural correctness. Returns nil if valid.
 func Place(p *models.Place) []FieldError {
 	if p == nil {
-		return []FieldError{{Field: "", Reason: "place is required"}}
+		return []FieldError{{Field: "body", Reason: "place is required"}}
 	}
 
 	var errs []FieldError
@@ -100,7 +100,7 @@ func Place(p *models.Place) []FieldError {
 		errs = append(errs, FieldError{Field: "rank", Reason: "must be 1, 2, or 3"})
 	}
 
-	if p.OSMID != 0 && p.OSMID < 0 {
+	if p.OSMID < 0 {
 		errs = append(errs, FieldError{Field: "osm_id", Reason: "must be positive"})
 	}
 

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package validation
+
+import (
+	"math"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-server/pkg/models"
+)
+
+func ptrFloat(v float64) *float64 { return &v }
+func ptrInt(v int) *int            { return &v }
+func ptrStr(v string) *string      { return &v }
+
+func validPlace() *models.Place {
+	return &models.Place{
+		Name:     "Test Cafe",
+		Lat:      52.5,
+		Lng:      13.4,
+		Category: models.CategoryCafe,
+	}
+}
+
+func errorsHaveField(errs []FieldError, field string) bool {
+	for _, e := range errs {
+		if e.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPlace_Valid(t *testing.T) {
+	if errs := Place(validPlace()); len(errs) != 0 {
+		t.Errorf("expected no errors, got %+v", errs)
+	}
+}
+
+func TestPlace_Required(t *testing.T) {
+	tests := []struct {
+		name  string
+		mut   func(p *models.Place)
+		field string
+	}{
+		{"missing name", func(p *models.Place) { p.Name = "" }, "name"},
+		{"whitespace name", func(p *models.Place) { p.Name = "   " }, "name"},
+		{"missing category", func(p *models.Place) { p.Category = "" }, "category"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validPlace()
+			tt.mut(p)
+			errs := Place(p)
+			if !errorsHaveField(errs, tt.field) {
+				t.Errorf("expected error on field %q, got %+v", tt.field, errs)
+			}
+		})
+	}
+}
+
+func TestPlace_Bounds(t *testing.T) {
+	tests := []struct {
+		name  string
+		mut   func(p *models.Place)
+		field string
+	}{
+		{"name too long", func(p *models.Place) { p.Name = strings.Repeat("a", maxNameLength+1) }, "name"},
+		{"lat above max", func(p *models.Place) { p.Lat = 91 }, "lat"},
+		{"lat below min", func(p *models.Place) { p.Lat = -91 }, "lat"},
+		{"lat NaN", func(p *models.Place) { p.Lat = math.NaN() }, "lat"},
+		{"lat Inf", func(p *models.Place) { p.Lat = math.Inf(1) }, "lat"},
+		{"lng above max", func(p *models.Place) { p.Lng = 181 }, "lng"},
+		{"lng below min", func(p *models.Place) { p.Lng = -181 }, "lng"},
+		{"invalid category", func(p *models.Place) { p.Category = "spaceship" }, "category"},
+		{"invalid rank", func(p *models.Place) { p.Rank = 4 }, "rank"},
+		{"negative osm_id", func(p *models.Place) { p.OSMID = -1 }, "osm_id"},
+		{"invalid osm_type", func(p *models.Place) { p.OSMType = "blob" }, "osm_type"},
+		{"source too long", func(p *models.Place) { p.Source = strings.Repeat("s", maxSourceLength+1) }, "source"},
+		{"invalid parent_id", func(p *models.Place) { p.ParentID = ptrStr("not-a-uuid") }, "parent_id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validPlace()
+			tt.mut(p)
+			errs := Place(p)
+			if !errorsHaveField(errs, tt.field) {
+				t.Errorf("expected error on field %q, got %+v", tt.field, errs)
+			}
+		})
+	}
+}
+
+func TestPlace_Edges(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(p *models.Place)
+	}{
+		{"lat at +90", func(p *models.Place) { p.Lat = 90 }},
+		{"lat at -90", func(p *models.Place) { p.Lat = -90 }},
+		{"lng at +180", func(p *models.Place) { p.Lng = 180 }},
+		{"lng at -180", func(p *models.Place) { p.Lng = -180 }},
+		{"name at max", func(p *models.Place) { p.Name = strings.Repeat("a", maxNameLength) }},
+		{"valid parent_id", func(p *models.Place) { p.ParentID = ptrStr("11111111-1111-1111-1111-111111111111") }},
+		{"valid rank=1", func(p *models.Place) { p.Rank = models.RankLandmark }},
+		{"valid osm_type", func(p *models.Place) { p.OSMID = 12345; p.OSMType = models.OSMNode }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validPlace()
+			tt.mut(p)
+			if errs := Place(p); len(errs) != 0 {
+				t.Errorf("expected no errors, got %+v", errs)
+			}
+		})
+	}
+}
+
+func TestPlace_Tags(t *testing.T) {
+	t.Run("too many entries", func(t *testing.T) {
+		p := validPlace()
+		p.Tags = make(models.PlaceTags, maxTagEntries+1)
+		for i := 0; i < maxTagEntries+1; i++ {
+			p.Tags[strings.Repeat("k", 1)+string(rune('a'+i%26))+string(rune('A'+i/26))] = "v"
+		}
+		if !errorsHaveField(Place(p), "tags") {
+			t.Errorf("expected error on tags")
+		}
+	})
+	t.Run("oversized value", func(t *testing.T) {
+		p := validPlace()
+		p.Tags = models.PlaceTags{"k": strings.Repeat("v", maxTagValueLength+1)}
+		if !errorsHaveField(Place(p), "tags") {
+			t.Errorf("expected error on tags")
+		}
+	})
+	t.Run("oversized key", func(t *testing.T) {
+		p := validPlace()
+		p.Tags = models.PlaceTags{strings.Repeat("k", maxTagKeyLength+1): "v"}
+		if !errorsHaveField(Place(p), "tags") {
+			t.Errorf("expected error on tags")
+		}
+	})
+}
+
+func TestAccessibilityProfile_Required(t *testing.T) {
+	errs := AccessibilityProfile(&models.AccessibilityProfile{})
+	if !errorsHaveField(errs, "overall_status") {
+		t.Errorf("expected error on overall_status, got %+v", errs)
+	}
+}
+
+func TestAccessibilityProfile_InvalidStatus(t *testing.T) {
+	prof := &models.AccessibilityProfile{OverallStatus: "questionable"}
+	if !errorsHaveField(AccessibilityProfile(prof), "overall_status") {
+		t.Errorf("expected error on overall_status")
+	}
+}
+
+func TestAccessibilityProfile_ComponentRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		comp  models.A11yComponent
+		field string
+	}{
+		{"missing type", models.A11yComponent{OverallStatus: models.StatusAccessible}, "components[0].type"},
+		{"invalid type", models.A11yComponent{Type: "wormhole"}, "components[0].type"},
+		{"invalid status", models.A11yComponent{Type: models.ComponentEntrance, OverallStatus: "?"}, "components[0].overall_status"},
+		{"entrance width over max", models.A11yComponent{Type: models.ComponentEntrance, Entrance: &models.EntranceProperties{Width: ptrFloat(11)}}, "components[0].entrance.width"},
+		{"entrance width negative", models.A11yComponent{Type: models.ComponentEntrance, Entrance: &models.EntranceProperties{Width: ptrFloat(-0.1)}}, "components[0].entrance.width"},
+		{"entrance step_height over max", models.A11yComponent{Type: models.ComponentEntrance, Entrance: &models.EntranceProperties{StepHeight: ptrFloat(2)}}, "components[0].entrance.step_height"},
+		{"restroom door over max", models.A11yComponent{Type: models.ComponentRestroom, Restroom: &models.RestroomProperties{DoorWidth: ptrFloat(11)}}, "components[0].restroom.door_width"},
+		{"elevator width over max", models.A11yComponent{Type: models.ComponentElevator, Elevator: &models.ElevatorProperties{Width: ptrFloat(11)}}, "components[0].elevator.width"},
+		{"elevator depth over max", models.A11yComponent{Type: models.ComponentElevator, Elevator: &models.ElevatorProperties{Depth: ptrFloat(11)}}, "components[0].elevator.depth"},
+		{"parking count negative", models.A11yComponent{Type: models.ComponentParking, Parking: &models.ParkingProperties{Count: ptrInt(-1)}}, "components[0].parking.count"},
+		{"parking count over max", models.A11yComponent{Type: models.ComponentParking, Parking: &models.ParkingProperties{Count: ptrInt(maxParkingCount + 1)}}, "components[0].parking.count"},
+		{"entrance width NaN", models.A11yComponent{Type: models.ComponentEntrance, Entrance: &models.EntranceProperties{Width: ptrFloat(math.NaN())}}, "components[0].entrance.width"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prof := &models.AccessibilityProfile{
+				OverallStatus: models.StatusAccessible,
+				Components:    models.A11yComponents{tt.comp},
+			}
+			errs := AccessibilityProfile(prof)
+			if !errorsHaveField(errs, tt.field) {
+				t.Errorf("expected error on %q, got %+v", tt.field, errs)
+			}
+		})
+	}
+}
+
+func TestPlaceID(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		{"valid", "11111111-1111-1111-1111-111111111111", true},
+		{"empty", "", false},
+		{"missing dashes", "11111111111111111111111111111111", false},
+		{"non-hex", "ZZZZZZZZ-1111-1111-1111-111111111111", false},
+		{"too short", "1111-1111-1111-1111-111111111111", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := PlaceID(tt.id)
+			gotValid := len(errs) == 0
+			if gotValid != tt.valid {
+				t.Errorf("PlaceID(%q) valid = %v, want %v", tt.id, gotValid, tt.valid)
+			}
+		})
+	}
+}
+
+func TestPlacesQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		valid bool
+	}{
+		{"empty", "", true},
+		{"valid circular", "lng=13.4&lat=52.5&radius=500", true},
+		{"valid bbox", "min_lng=13.0&min_lat=52.0&max_lng=14.0&max_lat=53.0", true},
+		{"partial circular", "lng=13.4&lat=52.5", false},
+		{"partial bbox", "min_lng=13.0&min_lat=52.0&max_lng=14.0", false},
+		{"both modes", "lng=13.4&lat=52.5&radius=500&min_lng=13.0&min_lat=52.0&max_lng=14.0&max_lat=53.0", false},
+		{"radius zero", "lng=13.4&lat=52.5&radius=0", false},
+		{"radius negative", "lng=13.4&lat=52.5&radius=-10", false},
+		{"radius too large", "lng=13.4&lat=52.5&radius=99999", false},
+		{"lat out of range", "lng=13.4&lat=91&radius=500", false},
+		{"lng out of range", "lng=181&lat=52.5&radius=500", false},
+		{"swapped bbox lng", "min_lng=14.0&min_lat=52.0&max_lng=13.0&max_lat=53.0", false},
+		{"swapped bbox lat", "min_lng=13.0&min_lat=53.0&max_lng=14.0&max_lat=52.0", false},
+		{"NaN circular", "lng=NaN&lat=52.5&radius=500", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, _ := url.ParseQuery(tt.query)
+			errs := PlacesQuery(q)
+			gotValid := len(errs) == 0
+			if gotValid != tt.valid {
+				t.Errorf("query=%q valid=%v, want %v; errs=%+v", tt.query, gotValid, tt.valid, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- New \`internal/validation\` package: structural input validation that runs **before** the a11y engine
- Enforces: required fields (\`name\`, \`lat\`, \`lng\`, \`category\`), coordinate bounds (lat ∈ [-90,90], lng ∈ [-180,180]), enum membership (\`Category\`, \`Rank\`, \`OSMType\`, \`A11yStatus\`, \`A11yComponentType\`), length caps (name ≤256, source ≤64, tags ≤50 entries), UUID format on path params, and component-property numeric bounds (widths ≤10m, step height ≤1m, parking count ≤10000, metadata ≤4 KB)
- New 400 response shape parallels the existing 422 conflict shape:

\`\`\`json
{
  "error": "validation failed",
  "fields": [{"field": "lat", "reason": "must be between -90 and 90"}]
}
\`\`\`

- Removes inline \`parseCoord\` from \`handleGetPlaces\` — query-param validation now lives in \`validation.PlacesQuery\`
- UUID format check on \`{id}\` path params prevents malformed IDs from becoming DB-driver 500s

## Test plan

- [x] Unit tests for every rule (table-driven in \`internal/validation/validation_test.go\`)
- [x] Handler-level 400 tests for each new validation entry point
- [x] All existing tests remain green (unit + integration)
- [x] \`go vet\` and \`golangci-lint\` clean

Closes #6