### PR TITLE
feat: add key revocation endpoint and graceful shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,8 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/claude-code-review.yml
     secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write

--- a/cmd/api/auth_integration_test.go
+++ b/cmd/api/auth_integration_test.go
@@ -311,6 +311,66 @@ func TestHandleRegister_XFFDoesNotBypassRateLimit(t *testing.T) {
 	}
 }
 
+// --- Revocation tests ---
+
+func TestHandleRevokeKey_Success(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	srv := newTestServer(t)
+	rawKey := registerKey(t, srv, "revoke@example.com")
+
+	r := httptest.NewRequest(http.MethodDelete, "/auth/keys", nil)
+	r.Header.Set("Authorization", "Bearer "+rawKey)
+	w := httptest.NewRecorder()
+	srv.handleRevokeKey(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("revoke: status = %d, want 204; body: %s", w.Code, w.Body.String())
+	}
+
+	// Revoked key must no longer authenticate.
+	body, _ := json.Marshal(models.Place{Name: "X", Lat: 60.1, Lng: 24.9, Category: models.CategoryCafe, Rank: models.RankEstablishment})
+	r = httptest.NewRequest(http.MethodPost, "/places", bytes.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+rawKey)
+	w = httptest.NewRecorder()
+	middleware.RequireAPIKey(testDB, srv.keyLimiter, srv.handlePostPlace)(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("revoked key: status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleRevokeKey_Unauthenticated(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	r := httptest.NewRequest(http.MethodDelete, "/auth/keys", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleRevokeKey(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleRevokeKey_AlreadyRevoked(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	srv := newTestServer(t)
+	rawKey := registerKey(t, srv, "revoke2@example.com")
+
+	now := time.Now()
+	testDB.Model(&models.APIKey{}).Where("email = ?", "revoke2@example.com").Update("revoked_at", now)
+
+	r := httptest.NewRequest(http.MethodDelete, "/auth/keys", nil)
+	r.Header.Set("Authorization", "Bearer "+rawKey)
+	w := httptest.NewRecorder()
+	srv.handleRevokeKey(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestHandleRegister_ConcurrentSameEmail verifies the DB-level partial unique index
 // (WHERE revoked_at IS NULL) prevents two simultaneous registrations for the same email
 // from both succeeding when the application-level check races.

--- a/cmd/api/handle_revoke.go
+++ b/cmd/api/handle_revoke.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-server/internal/middleware"
+	"github.com/InWheelOrg/inwheel-server/pkg/models"
+	"gorm.io/gorm"
+)
+
+// handleRevokeKey handles DELETE /auth/keys.
+// The bearer token in the Authorization header identifies which key to revoke.
+func (s *Server) handleRevokeKey(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		jsonResponse(w, map[string]string{"error": "unauthorized"}, http.StatusUnauthorized)
+		return
+	}
+
+	hash := middleware.SHA256Hex(strings.TrimPrefix(authHeader, "Bearer "))
+
+	var apiKey models.APIKey
+	err := s.db.Where("key_hash = ? AND revoked_at IS NULL", hash).First(&apiKey).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			jsonResponse(w, map[string]string{"error": "unauthorized"}, http.StatusUnauthorized)
+			return
+		}
+		slog.Error("revoke: key lookup failed", "error", err)
+		jsonResponse(w, map[string]string{"error": "internal server error"}, http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.db.Model(&apiKey).Update("revoked_at", time.Now()).Error; err != nil {
+		slog.Error("revoke: update failed", "error", err)
+		jsonResponse(w, map[string]string{"error": "internal server error"}, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,7 +12,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/InWheelOrg/inwheel-server/internal/a11y"
@@ -69,11 +71,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	srv := &Server{
 		db:         gormDB,
 		engine:     &a11y.Engine{},
-		regLimiter: middleware.NewRateLimiter(context.Background(), rate.Every(20*time.Minute), 3), // 3 registrations/hour/IP
-		keyLimiter: middleware.NewRateLimiter(context.Background(), rate.Every(time.Second), 60),   // 60 writes/min/key
+		regLimiter: middleware.NewRateLimiter(ctx, rate.Every(20*time.Minute), 3), // 3 registrations/hour/IP
+		keyLimiter: middleware.NewRateLimiter(ctx, rate.Every(time.Second), 60),   // 60 writes/min/key
 	}
 
 	mux := http.NewServeMux()
@@ -82,6 +87,7 @@ func main() {
 	mux.HandleFunc("GET /places", srv.handleGetPlaces)
 	mux.HandleFunc("GET /places/{id}", srv.handleGetPlace)
 	mux.HandleFunc("POST /auth/register", srv.handleRegister)
+	mux.HandleFunc("DELETE /auth/keys", srv.handleRevokeKey)
 	mux.HandleFunc("POST /places", middleware.RequireAPIKey(gormDB, srv.keyLimiter, srv.handlePostPlace))
 	mux.HandleFunc("PATCH /places/{id}/accessibility", middleware.RequireAPIKey(gormDB, srv.keyLimiter, srv.handlePatchAccessibility))
 
@@ -96,9 +102,21 @@ func main() {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	slog.Info("Starting Public API", "addr", srvAddr)
-	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		slog.Error("HTTP server failed", "error", err)
+	go func() {
+		slog.Info("Starting Public API", "addr", srvAddr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("HTTP server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+	slog.Info("Shutting down server...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		slog.Error("Server shutdown failed", "error", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -72,7 +72,6 @@ func main() {
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	srv := &Server{
 		db:         gormDB,
@@ -114,11 +113,12 @@ func main() {
 	stop()
 	slog.Info("Shutting down server...")
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		cancel()
 		slog.Error("Server shutdown failed", "error", err)
 		os.Exit(1)
 	}
+	cancel()
 }
 
 // handleGetPlaces handles requests for a list of places, supporting two types of spatial filters.


### PR DESCRIPTION
## Summary

- `DELETE /auth/keys` revokes the authenticated caller's own API key by setting `revoked_at`; no path param needed since the bearer token identifies the key
- `main()` now uses `signal.NotifyContext` so rate-limiter goroutines stop cleanly on SIGTERM/SIGINT and in-flight requests drain within a 30-second window before the process exits

## Test plan

- [x] `TestHandleRevokeKey_Success` — key stops authenticating after revocation
- [x] `TestHandleRevokeKey_Unauthenticated` — 401 with no auth header
- [x] `TestHandleRevokeKey_AlreadyRevoked` — 401 when key is already revoked
- [x] All existing auth integration tests still pass

Closes #37, closes #38