### PR TITLE
Add cursor-based pagination to GET /places

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,32 @@ Child places inherit accessibility components from their parent for any componen
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/places` | List places. Supports proximity (`lat`, `lng`, `radius`) and bounding box (`min_lng`, `min_lat`, `max_lng`, `max_lat`) |
+| `GET` | `/places` | List places with cursor-based pagination. Supports proximity (`lat`, `lng`, `radius`) and bounding box (`min_lng`, `min_lat`, `max_lng`, `max_lat`) filters |
 | `GET` | `/places/{id}` | Get a single place with its accessibility profile |
 | `POST` | `/places` | Create a place (with optional accessibility data) |
 | `PATCH` | `/places/{id}/accessibility` | Update or create an accessibility profile |
+
+### GET /places — query parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `limit` | integer | `20` | Number of results per page. Range: 1–100 |
+| `cursor` | string | — | Opaque pagination cursor from a prior response's `next_cursor` field |
+| `lng`, `lat`, `radius` | float | — | Proximity filter: centre point and radius in metres (max 50 000) |
+| `min_lng`, `min_lat`, `max_lng`, `max_lat` | float | — | Bounding box filter |
+
+`lng/lat/radius` and the bounding-box params are mutually exclusive. Proximity and bounding-box modes both support `limit` and `cursor`.
+
+**Response shape:**
+
+```json
+{
+  "data": [ /* array of Place objects */ ],
+  "next_cursor": "base64-encoded-cursor"
+}
+```
+
+`next_cursor` is omitted when there are no further pages.
 
 ## Running with Docker Compose
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -147,8 +147,9 @@ func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 	scope := s.db.Preload("Accessibility").Order("updated_at DESC, id ASC").Limit(limit + 1)
 
 	if c := q.Get("cursor"); c != "" {
-		cursorTS, cursorID, _ := pagination.Decode(c) // already validated
-		scope = scope.Where("updated_at < ? OR (updated_at = ? AND id > ?)", cursorTS, cursorTS, cursorID)
+		if cursorTS, cursorID, err := pagination.Decode(c); err == nil {
+			scope = scope.Where("places.updated_at < ? OR (places.updated_at = ? AND places.id > ?)", cursorTS, cursorTS, cursorID)
+		}
 	}
 
 	places := make([]models.Place, 0)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/InWheelOrg/inwheel-server/internal/db"
 	"github.com/InWheelOrg/inwheel-server/internal/geo"
 	"github.com/InWheelOrg/inwheel-server/internal/middleware"
+	"github.com/InWheelOrg/inwheel-server/internal/pagination"
 	"github.com/InWheelOrg/inwheel-server/internal/validation"
 	"github.com/InWheelOrg/inwheel-server/pkg/models"
 	"golang.org/x/time/rate"
@@ -121,13 +122,15 @@ func main() {
 	cancel()
 }
 
-// handleGetPlaces handles requests for a list of places, supporting two types of spatial filters.
+// handleGetPlaces lists places with cursor-based pagination.
 //
-// If 'lng', 'lat', and 'radius' are provided, it performs a circular proximity search.
-// If 'min_lng', 'min_lat', 'max_lng', and 'max_lat' are provided, it performs a bounding box search.
+// Supports three query modes (validated before this point):
+//   - Proximity: lng, lat, radius
+//   - Bounding box: min_lng, min_lat, max_lng, max_lat
+//   - Default: most recently updated places
 //
-// If no spatial parameters are present, it defaults to returning the most recently updated 100 places.
-// Returns 400 with a structured field-error list if any query param is malformed or out of bounds.
+// Pagination params: limit (default 20, max 100), cursor (opaque, from a prior response).
+// Response: {"data": [...], "next_cursor": "..."} — next_cursor absent on the last page.
 func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	if errs := validation.PlacesQuery(q); len(errs) > 0 {
@@ -135,7 +138,20 @@ func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var places []models.Place
+	limit := 20
+	if l := q.Get("limit"); l != "" {
+		limit, _ = strconv.Atoi(l)
+	}
+
+	// Fetch one extra to know whether a next page exists.
+	scope := s.db.Preload("Accessibility").Order("updated_at DESC, id ASC").Limit(limit + 1)
+
+	if c := q.Get("cursor"); c != "" {
+		cursorTS, cursorID, _ := pagination.Decode(c) // already validated
+		scope = scope.Where("updated_at < ? OR (updated_at = ? AND id > ?)", cursorTS, cursorTS, cursorID)
+	}
+
+	places := make([]models.Place, 0)
 	var err error
 
 	switch {
@@ -143,15 +159,15 @@ func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 		lng, _ := strconv.ParseFloat(q.Get("lng"), 64)
 		lat, _ := strconv.ParseFloat(q.Get("lat"), 64)
 		radius, _ := strconv.ParseFloat(q.Get("radius"), 64)
-		places, err = geo.FindNearbyPlaces(s.db, lng, lat, radius)
+		places, err = geo.FindNearbyPlaces(scope, lng, lat, radius)
 	case q.Get("min_lng") != "":
 		minLng, _ := strconv.ParseFloat(q.Get("min_lng"), 64)
 		minLat, _ := strconv.ParseFloat(q.Get("min_lat"), 64)
 		maxLng, _ := strconv.ParseFloat(q.Get("max_lng"), 64)
 		maxLat, _ := strconv.ParseFloat(q.Get("max_lat"), 64)
-		places, err = geo.FindPlacesInBoundingBox(s.db, minLng, minLat, maxLng, maxLat)
+		places, err = geo.FindPlacesInBoundingBox(scope, minLng, minLat, maxLng, maxLat)
 	default:
-		err = s.db.Preload("Accessibility").Order("updated_at DESC").Limit(100).Find(&places).Error
+		err = scope.Find(&places).Error
 	}
 
 	if err != nil {
@@ -159,7 +175,14 @@ func (s *Server) handleGetPlaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResponse(w, places, http.StatusOK)
+	var nextCursor string
+	if len(places) > limit {
+		places = places[:limit]
+		last := places[len(places)-1]
+		nextCursor = pagination.Encode(last.UpdatedAt, last.ID)
+	}
+
+	jsonResponse(w, pagination.Page[models.Place]{Data: places, NextCursor: nextCursor}, http.StatusOK)
 }
 
 // handleGetPlace returns the full details of a single place, including its accessibility profile.

--- a/cmd/api/places_integration_test.go
+++ b/cmd/api/places_integration_test.go
@@ -1,0 +1,387 @@
+//go:build integration
+
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-server/internal/pagination"
+	"github.com/InWheelOrg/inwheel-server/pkg/models"
+)
+
+// decodePageResponse decodes the paginated GET /places envelope.
+func decodePageResponse(t *testing.T, body []byte) ([]models.Place, string) {
+	t.Helper()
+	var page struct {
+		Data       []models.Place `json:"data"`
+		NextCursor string         `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(body, &page); err != nil {
+		t.Fatalf("decode page response: %v\nbody: %s", err, body)
+	}
+	return page.Data, page.NextCursor
+}
+
+func TestHandleGetPlaces_DefaultPagination(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	// Insert 3 places with distinct updated_at so ordering is deterministic.
+	for i := 0; i < 3; i++ {
+		p := models.Place{
+			Name:      fmt.Sprintf("Place %d", i),
+			Lat:       52.5,
+			Lng:       13.4,
+			Category:  models.CategoryCafe,
+			Source:    "test",
+			UpdatedAt: time.Now().Add(time.Duration(i) * time.Second),
+		}
+		testDB.Create(&p)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/places?limit=2", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	places, nextCursor := decodePageResponse(t, w.Body.Bytes())
+
+	if len(places) != 2 {
+		t.Errorf("got %d places, want 2", len(places))
+	}
+	if nextCursor == "" {
+		t.Error("expected next_cursor to be set when more results exist")
+	}
+}
+
+func TestHandleGetPlaces_LastPageHasNoCursor(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	for i := 0; i < 2; i++ {
+		p := models.Place{
+			Name:     fmt.Sprintf("Place %d", i),
+			Lat:      52.5,
+			Lng:      13.4,
+			Category: models.CategoryCafe,
+			Source:   "test",
+		}
+		testDB.Create(&p)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/places?limit=10", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	places, nextCursor := decodePageResponse(t, w.Body.Bytes())
+
+	if len(places) != 2 {
+		t.Errorf("got %d places, want 2", len(places))
+	}
+	if nextCursor != "" {
+		t.Errorf("expected no next_cursor on last page, got %q", nextCursor)
+	}
+}
+
+func TestHandleGetPlaces_CursorAdvancesPage(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	base := time.Now().UTC().Truncate(time.Microsecond)
+	var allIDs []string
+	for i := 0; i < 5; i++ {
+		p := models.Place{
+			Name:      fmt.Sprintf("Place %d", i),
+			Lat:       52.5,
+			Lng:       13.4,
+			Category:  models.CategoryCafe,
+			Source:    "test",
+			UpdatedAt: base.Add(time.Duration(i) * time.Second),
+		}
+		testDB.Create(&p)
+		allIDs = append(allIDs, p.ID)
+	}
+
+	// First page: expect 3 results and a cursor.
+	r1 := httptest.NewRequest(http.MethodGet, "/places?limit=3", nil)
+	w1 := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w1, r1)
+
+	if w1.Code != http.StatusOK {
+		t.Fatalf("page 1 status = %d; body: %s", w1.Code, w1.Body.String())
+	}
+	page1, cursor := decodePageResponse(t, w1.Body.Bytes())
+	if len(page1) != 3 {
+		t.Fatalf("page 1: got %d places, want 3", len(page1))
+	}
+	if cursor == "" {
+		t.Fatal("expected cursor after page 1")
+	}
+
+	// Second page using the cursor.
+	r2 := httptest.NewRequest(http.MethodGet, "/places?limit=3&cursor="+cursor, nil)
+	w2 := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w2, r2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d; body: %s", w2.Code, w2.Body.String())
+	}
+	page2, cursor2 := decodePageResponse(t, w2.Body.Bytes())
+	if len(page2) != 2 {
+		t.Fatalf("page 2: got %d places, want 2", len(page2))
+	}
+	if cursor2 != "" {
+		t.Errorf("expected no cursor after last page, got %q", cursor2)
+	}
+
+	// No overlap between pages.
+	page1IDs := make(map[string]bool)
+	for _, p := range page1 {
+		page1IDs[p.ID] = true
+	}
+	for _, p := range page2 {
+		if page1IDs[p.ID] {
+			t.Errorf("place %q appeared in both page 1 and page 2", p.ID)
+		}
+	}
+}
+
+func TestHandleGetPlaces_DefaultLimitIs20(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	for i := 0; i < 25; i++ {
+		p := models.Place{
+			Name:     fmt.Sprintf("Place %d", i),
+			Lat:      52.5,
+			Lng:      13.4,
+			Category: models.CategoryCafe,
+			Source:   "test",
+		}
+		testDB.Create(&p)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/places", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	places, _ := decodePageResponse(t, w.Body.Bytes())
+	if len(places) != 20 {
+		t.Errorf("got %d places with no limit param, want 20 (default)", len(places))
+	}
+}
+
+func TestHandleGetPlaces_InvalidCursorReturns400(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/places?cursor=not-valid-base64!!!!", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleGetPlaces_InvalidLimitReturns400(t *testing.T) {
+	for _, bad := range []string{"0", "101", "abc", "-5"} {
+		t.Run(bad, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/places?limit="+bad, nil)
+			w := httptest.NewRecorder()
+			newTestServer(t).handleGetPlaces(w, r)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("limit=%s: status = %d, want 400", bad, w.Code)
+			}
+		})
+	}
+}
+
+func TestHandleGetPlaces_ProximityPaginated(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	// 5 places in Berlin, 1 far away.
+	berlin := []models.Place{}
+	for i := 0; i < 5; i++ {
+		p := models.Place{
+			Name:     fmt.Sprintf("Berlin Place %d", i),
+			Lat:      52.52 + float64(i)*0.001,
+			Lng:      13.405,
+			Category: models.CategoryCafe,
+			Source:   "test",
+		}
+		testDB.Create(&p)
+		berlin = append(berlin, p)
+	}
+	london := models.Place{Name: "London", Lat: 51.507, Lng: -0.127, Category: models.CategoryCafe, Source: "test"}
+	testDB.Create(&london)
+
+	// First page of proximity query.
+	r := httptest.NewRequest(http.MethodGet, "/places?lng=13.405&lat=52.52&radius=5000&limit=3", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	places, cursor := decodePageResponse(t, w.Body.Bytes())
+	if len(places) != 3 {
+		t.Errorf("got %d places, want 3", len(places))
+	}
+	if cursor == "" {
+		t.Error("expected cursor with more results remaining")
+	}
+
+	// Second page.
+	r2 := httptest.NewRequest(http.MethodGet, "/places?lng=13.405&lat=52.52&radius=5000&limit=3&cursor="+cursor, nil)
+	w2 := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w2, r2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d; body: %s", w2.Code, w2.Body.String())
+	}
+	places2, _ := decodePageResponse(t, w2.Body.Bytes())
+	if len(places2) != 2 {
+		t.Errorf("page 2: got %d places, want 2", len(places2))
+	}
+	// London should not appear in either page (outside radius).
+	for _, p := range append(places, places2...) {
+		if p.Name == "London" {
+			t.Error("London should be outside the 5km radius")
+		}
+	}
+}
+
+func TestHandleGetPlaces_BoundingBoxPaginated(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	for i := 0; i < 4; i++ {
+		p := models.Place{
+			Name:     fmt.Sprintf("Berlin %d", i),
+			Lat:      52.5 + float64(i)*0.01,
+			Lng:      13.4,
+			Category: models.CategoryCafe,
+			Source:   "test",
+		}
+		testDB.Create(&p)
+	}
+	london := models.Place{Name: "London", Lat: 51.507, Lng: -0.127, Category: models.CategoryCafe, Source: "test"}
+	testDB.Create(&london)
+
+	r := httptest.NewRequest(http.MethodGet, "/places?min_lng=10.0&min_lat=50.0&max_lng=15.0&max_lat=55.0&limit=3", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	places, cursor := decodePageResponse(t, w.Body.Bytes())
+	if len(places) != 3 {
+		t.Errorf("got %d places, want 3", len(places))
+	}
+	if cursor == "" {
+		t.Error("expected cursor with 1 more result")
+	}
+
+	r2 := httptest.NewRequest(http.MethodGet, "/places?min_lng=10.0&min_lat=50.0&max_lng=15.0&max_lat=55.0&limit=3&cursor="+cursor, nil)
+	w2 := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w2, r2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d; body: %s", w2.Code, w2.Body.String())
+	}
+	places2, cursor2 := decodePageResponse(t, w2.Body.Bytes())
+	if len(places2) != 1 {
+		t.Errorf("page 2: got %d places, want 1", len(places2))
+	}
+	if cursor2 != "" {
+		t.Errorf("expected no cursor on last page, got %q", cursor2)
+	}
+	for _, p := range append(places, places2...) {
+		if p.Name == "London" {
+			t.Error("London is outside bounding box and should not appear")
+		}
+	}
+}
+
+func TestHandleGetPlaces_PreloadsAccessibility(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	p := models.Place{
+		Name:     "Accessible Cafe",
+		Lat:      52.5,
+		Lng:      13.4,
+		Category: models.CategoryCafe,
+		Source:   "test",
+		Accessibility: &models.AccessibilityProfile{
+			OverallStatus: models.StatusAccessible,
+		},
+	}
+	testDB.Create(&p)
+
+	r := httptest.NewRequest(http.MethodGet, "/places", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	places, _ := decodePageResponse(t, w.Body.Bytes())
+	if len(places) != 1 {
+		t.Fatalf("got %d places, want 1", len(places))
+	}
+	if places[0].Accessibility == nil {
+		t.Error("expected accessibility to be preloaded in GET /places response")
+	}
+}
+
+func TestHandleGetPlaces_EmptyDB(t *testing.T) {
+	t.Cleanup(func() { truncate(t) })
+
+	r := httptest.NewRequest(http.MethodGet, "/places", nil)
+	w := httptest.NewRecorder()
+	newTestServer(t).handleGetPlaces(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	places, cursor := decodePageResponse(t, w.Body.Bytes())
+	if len(places) != 0 {
+		t.Errorf("got %d places, want 0", len(places))
+	}
+	if cursor != "" {
+		t.Errorf("expected no cursor for empty result, got %q", cursor)
+	}
+}
+
+// Verify the pagination.Encode/Decode round-trip survives URL query encoding.
+func TestHandleGetPlaces_CursorURLSafe(t *testing.T) {
+	ts := time.Now().UTC()
+	id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	encoded := pagination.Encode(ts, id)
+
+	// The cursor should survive being used as a query param.
+	q := "cursor=" + encoded
+	parsed, err := http.NewRequest(http.MethodGet, "/places?"+q, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	got := parsed.URL.Query().Get("cursor")
+	if got != encoded {
+		t.Errorf("cursor mangled in URL: got %q, want %q", got, encoded)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/docker/go-connections v0.6.0
 	github.com/golang-migrate/migrate/v4 v4.18.3
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.0
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
@@ -33,7 +34,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/internal/db/migrations/000004_add_places_pagination_index.down.sql
+++ b/internal/db/migrations/000004_add_places_pagination_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_places_pagination;

--- a/internal/db/migrations/000004_add_places_pagination_index.up.sql
+++ b/internal/db/migrations/000004_add_places_pagination_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_places_pagination
+    ON places (updated_at DESC, id ASC);

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -4,18 +4,18 @@
  */
 
 // Package pagination provides cursor-based pagination helpers for the InWheel API.
-// Cursors are opaque base64-encoded strings encoding a timestamp and UUID.
+// Cursors are base64url-encoded but not signed — do not reuse on endpoints where
+// cursor integrity or per-user isolation matters.
 package pagination
 
 import (
 	"encoding/base64"
 	"errors"
-	"regexp"
 	"strings"
 	"time"
-)
 
-var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	"github.com/google/uuid"
+)
 
 // Page is the standard paginated response envelope returned by list endpoints.
 type Page[T any] struct {
@@ -23,9 +23,10 @@ type Page[T any] struct {
 	NextCursor string `json:"next_cursor,omitempty"`
 }
 
-// Encode produces a base64-encoded opaque cursor from a timestamp and UUID.
+// Encode produces a base64url-encoded cursor from a timestamp and UUID.
+// Truncates to µs to match PostgreSQL timestamptz precision.
 func Encode(t time.Time, id string) string {
-	raw := t.UTC().Format(time.RFC3339Nano) + "|" + id
+	raw := t.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano) + "|" + id
 	return base64.RawURLEncoding.EncodeToString([]byte(raw))
 }
 
@@ -43,7 +44,7 @@ func Decode(cursor string) (time.Time, string, error) {
 	if err != nil {
 		return time.Time{}, "", errors.New("invalid cursor timestamp")
 	}
-	if !uuidRegex.MatchString(parts[1]) {
+	if _, err := uuid.Parse(parts[1]); err != nil {
 		return time.Time{}, "", errors.New("invalid cursor id")
 	}
 	return t, parts[1], nil

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Package pagination provides cursor-based pagination helpers for the InWheel API.
+// Cursors are opaque base64-encoded strings encoding a timestamp and UUID.
+package pagination
+
+import (
+	"encoding/base64"
+	"errors"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// Page is the standard paginated response envelope returned by list endpoints.
+type Page[T any] struct {
+	Data       []T    `json:"data"`
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+// Encode produces a base64-encoded opaque cursor from a timestamp and UUID.
+func Encode(t time.Time, id string) string {
+	raw := t.UTC().Format(time.RFC3339Nano) + "|" + id
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+// Decode parses a cursor produced by Encode and returns its timestamp and UUID components.
+func Decode(cursor string) (time.Time, string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", errors.New("invalid cursor encoding")
+	}
+	parts := strings.SplitN(string(b), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, "", errors.New("invalid cursor format")
+	}
+	t, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, "", errors.New("invalid cursor timestamp")
+	}
+	if !uuidRegex.MatchString(parts[1]) {
+		return time.Time{}, "", errors.New("invalid cursor id")
+	}
+	return t, parts[1], nil
+}

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-func TestEncodeDecodRoundTrip(t *testing.T) {
-	ts := time.Date(2026, 5, 1, 12, 0, 0, 123456789, time.UTC)
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 123456000, time.UTC)
 	id := "11111111-2222-3333-4444-555555555555"
 
 	cursor := Encode(ts, id)

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package pagination
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+)
+
+func TestEncodeDecodRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 123456789, time.UTC)
+	id := "11111111-2222-3333-4444-555555555555"
+
+	cursor := Encode(ts, id)
+
+	gotTS, gotID, err := Decode(cursor)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if !gotTS.Equal(ts) {
+		t.Errorf("timestamp = %v, want %v", gotTS, ts)
+	}
+	if gotID != id {
+		t.Errorf("id = %q, want %q", gotID, id)
+	}
+}
+
+func TestDecodeInvalidBase64(t *testing.T) {
+	_, _, err := Decode("not!valid!base64!!!!")
+	if err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestDecodeNoSeparator(t *testing.T) {
+	raw := base64.RawURLEncoding.EncodeToString([]byte("2026-05-01T12:00:00Z"))
+	_, _, err := Decode(raw)
+	if err == nil {
+		t.Error("expected error when separator is missing")
+	}
+}
+
+func TestDecodeInvalidTimestamp(t *testing.T) {
+	raw := base64.RawURLEncoding.EncodeToString([]byte("not-a-timestamp|11111111-2222-3333-4444-555555555555"))
+	_, _, err := Decode(raw)
+	if err == nil {
+		t.Error("expected error for invalid timestamp")
+	}
+}
+
+func TestDecodeInvalidUUID(t *testing.T) {
+	raw := base64.RawURLEncoding.EncodeToString([]byte("2026-05-01T12:00:00Z|not-a-uuid"))
+	_, _, err := Decode(raw)
+	if err == nil {
+		t.Error("expected error for invalid uuid")
+	}
+}
+
+func TestEncodeIsAlwaysUTC(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Helsinki")
+	ts := time.Date(2026, 5, 1, 15, 0, 0, 0, loc) // UTC+3
+
+	cursor := Encode(ts, "11111111-2222-3333-4444-555555555555")
+	gotTS, _, _ := Decode(cursor)
+
+	if gotTS.Location() != time.UTC {
+		t.Errorf("decoded timestamp location = %v, want UTC", gotTS.Location())
+	}
+	if !gotTS.Equal(ts) {
+		t.Errorf("decoded timestamp = %v, want %v (in UTC)", gotTS, ts.UTC())
+	}
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/InWheelOrg/inwheel-server/internal/pagination"
 	"github.com/InWheelOrg/inwheel-server/pkg/models"
 )
 
@@ -231,6 +232,19 @@ func PlacesQuery(q url.Values) []FieldError {
 		}
 		if e2 == nil && e4 == nil && minLat >= maxLat {
 			errs = append(errs, FieldError{Field: "min_lat", Reason: "must be less than max_lat"})
+		}
+	}
+
+	if l := q.Get("limit"); l != "" {
+		n, err := strconv.Atoi(l)
+		if err != nil || n < 1 || n > 100 {
+			errs = append(errs, FieldError{Field: "limit", Reason: "must be an integer between 1 and 100"})
+		}
+	}
+
+	if c := q.Get("cursor"); c != "" {
+		if _, _, err := pagination.Decode(c); err != nil {
+			errs = append(errs, FieldError{Field: "cursor", Reason: "invalid cursor"})
 		}
 	}
 

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -6,6 +6,7 @@
 package validation
 
 import (
+	"encoding/base64"
 	"math"
 	"net/url"
 	"strings"
@@ -13,6 +14,10 @@ import (
 
 	"github.com/InWheelOrg/inwheel-server/pkg/models"
 )
+
+func b64Enc(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
 
 func ptrFloat(v float64) *float64 { return &v }
 func ptrInt(v int) *int            { return &v }
@@ -267,6 +272,77 @@ func TestPlacesQuery(t *testing.T) {
 			gotValid := len(errs) == 0
 			if gotValid != tt.valid {
 				t.Errorf("query=%q valid=%v, want %v; errs=%+v", tt.query, gotValid, tt.valid, errs)
+			}
+		})
+	}
+}
+
+func TestPlacesQuery_LimitParam(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+		field   string
+	}{
+		{"no limit", "", false, ""},
+		{"limit 1", "limit=1", false, ""},
+		{"limit 20", "limit=20", false, ""},
+		{"limit 100", "limit=100", false, ""},
+		{"limit 0", "limit=0", true, "limit"},
+		{"limit negative", "limit=-1", true, "limit"},
+		{"limit 101", "limit=101", true, "limit"},
+		{"limit non-integer", "limit=abc", true, "limit"},
+		{"limit float", "limit=1.5", true, "limit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, _ := url.ParseQuery(tt.query)
+			errs := PlacesQuery(q)
+			if tt.wantErr {
+				if !errorsHaveField(errs, tt.field) {
+					t.Errorf("expected error on %q field, got %+v", tt.field, errs)
+				}
+			} else if len(errs) != 0 {
+				t.Errorf("expected no errors, got %+v", errs)
+			}
+		})
+	}
+}
+
+func TestPlacesQuery_CursorParam(t *testing.T) {
+	const validTS = "2026-05-01T12:00:00Z"
+	const validID = "11111111-2222-3333-4444-555555555555"
+
+	b64 := func(s string) string {
+		return b64Enc([]byte(s))
+	}
+
+	tests := []struct {
+		name    string
+		cursor  string
+		wantErr bool
+	}{
+		{"no cursor", "", false},
+		{"invalid base64", "!!!!", true},
+		{"no pipe separator", b64("no-pipe-here"), true},
+		{"bad timestamp", b64("not-a-time|" + validID), true},
+		{"bad uuid", b64(validTS + "|not-a-uuid"), true},
+		{"valid cursor", b64(validTS + "|" + validID), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rawQuery string
+			if tt.cursor != "" {
+				rawQuery = "cursor=" + url.QueryEscape(tt.cursor)
+			}
+			q, _ := url.ParseQuery(rawQuery)
+			errs := PlacesQuery(q)
+			if tt.wantErr {
+				if !errorsHaveField(errs, "cursor") {
+					t.Errorf("expected error on cursor field, got %+v", errs)
+				}
+			} else if errorsHaveField(errs, "cursor") {
+				t.Errorf("expected no cursor error, got %+v", errs)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Replaces the hard-coded 100-row cap on `GET /places` with proper cursor-based pagination, applied consistently across all three query branches (default, proximity, bounding box).

## Changes

- **Migration 000004** — composite index `(updated_at DESC, id ASC)` on `places` to back efficient cursor queries
- **`internal/pagination`** — new package: `Encode`/`Decode` for opaque base64 cursors (`timestamp|uuid`), and `Page[T]` response envelope
- **`internal/validation`** — `PlacesQuery` now validates `limit` (integer, 1–100) and `cursor` (valid base64 timestamp+uuid)
- **`cmd/api/main.go`** — refactored `handleGetPlaces`: default limit 20, cursor `WHERE` clause (`updated_at < ? OR (updated_at = ? AND id > ?)`), all three branches preload `Accessibility`, response wrapped in `{"data": [...], "next_cursor": "..."}` envelope
- **Geo functions** unchanged — handler passes a pre-scoped `*gorm.DB` so no signature changes were needed
- **Tests** — unit tests for cursor encode/decode and new validation params; integration tests for paginated default, proximity, and bbox queries, last-page detection, empty DB, invalid inputs, and accessibility preloading

## Response shape

```json
{
  "data": [ /* Place objects */ ],
  "next_cursor": "base64cursor"
}
```

`next_cursor` is omitted on the last page. Clients pass it as `?cursor=` on the next request.

Closes #8