### PR TITLE
Remove string roundtrip in PlacesQuery validation

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -187,7 +187,11 @@ func bodySizeLimiter(maxBytes int64) apiv1.MiddlewareFunc {
 func (s *Server) ListPlaces(ctx context.Context, request apiv1.ListPlacesRequestObject) (apiv1.ListPlacesResponseObject, error) {
 	q := request.Params
 
-	if errs := validation.PlacesQuery(buildRawQuery(q)); len(errs) > 0 {
+	if errs := validation.PlacesQuery(validation.PlacesQueryParams{
+		Lng: q.Lng, Lat: q.Lat, Radius: q.Radius,
+		MinLng: q.MinLng, MinLat: q.MinLat, MaxLng: q.MaxLng, MaxLat: q.MaxLat,
+		Cursor: q.Cursor,
+	}); len(errs) > 0 {
 		return apiv1.ListPlaces400JSONResponse(validationError(errs)), nil
 	}
 
@@ -379,26 +383,6 @@ func writeJSON(w http.ResponseWriter, data any, code int) {
 	if err := enc.Encode(data); err != nil {
 		slog.Error("writeJSON: encode failed", "error", err)
 	}
-}
-
-func buildRawQuery(p apiv1.ListPlacesParams) map[string][]string {
-	q := make(map[string][]string)
-	setFloat := func(key string, v *float64) {
-		if v != nil {
-			q[key] = []string{strconv.FormatFloat(*v, 'f', -1, 64)}
-		}
-	}
-	setFloat("lng", p.Lng)
-	setFloat("lat", p.Lat)
-	setFloat("radius", p.Radius)
-	setFloat("min_lng", p.MinLng)
-	setFloat("min_lat", p.MinLat)
-	setFloat("max_lng", p.MaxLng)
-	setFloat("max_lat", p.MaxLat)
-	if p.Cursor != nil {
-		q["cursor"] = []string{*p.Cursor}
-	}
-	return q
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -13,9 +13,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/InWheelOrg/inwheel-server/internal/pagination"
@@ -73,20 +71,31 @@ func Place(p *models.Place) []FieldError {
 	return errs
 }
 
+// PlacesQueryParams holds the typed query parameters for GET /places.
+// It mirrors the oapi-codegen–generated ListPlacesParams but lives in this
+// package to avoid an upward import dependency on internal/api/v1.
+type PlacesQueryParams struct {
+	Lng    *float64
+	Lat    *float64
+	Radius *float64
+	MinLng *float64
+	MinLat *float64
+	MaxLng *float64
+	MaxLat *float64
+	Cursor *string
+}
+
 // PlacesQuery validates constraints on GET /places query params that OpenAPI
 // cannot express: mutual exclusivity of proximity vs bbox param groups,
 // bounding-box ordering (min < max), and cursor internal format.
-func PlacesQuery(q url.Values) []FieldError {
-	circular := []string{q.Get("lng"), q.Get("lat"), q.Get("radius")}
-	bbox := []string{q.Get("min_lng"), q.Get("min_lat"), q.Get("max_lng"), q.Get("max_lat")}
+func PlacesQuery(p PlacesQueryParams) []FieldError {
+	circularPresent := countNonNilFloats(p.Lng, p.Lat, p.Radius)
+	bboxPresent := countNonNilFloats(p.MinLng, p.MinLat, p.MaxLng, p.MaxLat)
 
-	circularPresent := nonEmptyCount(circular)
-	bboxPresent := nonEmptyCount(bbox)
-
-	if circularPresent != 0 && circularPresent != len(circular) {
+	if circularPresent != 0 && circularPresent != 3 {
 		return []FieldError{{Field: "query", Reason: "lng, lat, and radius must all be provided together"}}
 	}
-	if bboxPresent != 0 && bboxPresent != len(bbox) {
+	if bboxPresent != 0 && bboxPresent != 4 {
 		return []FieldError{{Field: "query", Reason: "min_lng, min_lat, max_lng, and max_lat must all be provided together"}}
 	}
 	if circularPresent > 0 && bboxPresent > 0 {
@@ -95,26 +104,17 @@ func PlacesQuery(q url.Values) []FieldError {
 
 	var errs []FieldError
 
-	if bboxPresent == len(bbox) {
-		minLng, e1 := strconv.ParseFloat(q.Get("min_lng"), 64)
-		minLat, e2 := strconv.ParseFloat(q.Get("min_lat"), 64)
-		maxLng, e3 := strconv.ParseFloat(q.Get("max_lng"), 64)
-		maxLat, e4 := strconv.ParseFloat(q.Get("max_lat"), 64)
-
-		if e1 == nil && e3 == nil && minLng >= maxLng {
+	if bboxPresent == 4 {
+		if *p.MinLng >= *p.MaxLng {
 			errs = append(errs, FieldError{Field: "min_lng", Reason: "must be less than max_lng"})
 		}
-		if e2 == nil && e4 == nil && minLat >= maxLat {
+		if *p.MinLat >= *p.MaxLat {
 			errs = append(errs, FieldError{Field: "min_lat", Reason: "must be less than max_lat"})
 		}
-		_ = e1
-		_ = e2
-		_ = e3
-		_ = e4
 	}
 
-	if c := q.Get("cursor"); c != "" {
-		if _, _, err := pagination.Decode(c); err != nil {
+	if p.Cursor != nil {
+		if _, _, err := pagination.Decode(*p.Cursor); err != nil {
 			errs = append(errs, FieldError{Field: "cursor", Reason: "invalid cursor"})
 		}
 	}
@@ -155,10 +155,10 @@ func validateMetadata(md map[string]any) []FieldError {
 	return nil
 }
 
-func nonEmptyCount(ss []string) int {
+func countNonNilFloats(ptrs ...*float64) int {
 	n := 0
-	for _, s := range ss {
-		if s != "" {
+	for _, p := range ptrs {
+		if p != nil {
 			n++
 		}
 	}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -7,7 +7,6 @@ package validation
 
 import (
 	"encoding/base64"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -110,25 +109,25 @@ func TestPlace_Tags(t *testing.T) {
 // Mutual exclusivity and group completeness — these cannot be expressed in the
 // OpenAPI spec and are the only query-param checks remaining in Go.
 func TestPlacesQuery_GroupRules(t *testing.T) {
+	f := ptrFloat
 	tests := []struct {
-		name  string
-		query string
-		valid bool
+		name   string
+		params PlacesQueryParams
+		valid  bool
 	}{
-		{"empty query", "", true},
-		{"full proximity group", "lng=13.4&lat=52.5&radius=500", true},
-		{"full bbox group", "min_lng=13.0&min_lat=52.0&max_lng=14.0&max_lat=53.0", true},
-		{"partial proximity — missing radius", "lng=13.4&lat=52.5", false},
-		{"partial proximity — missing lat", "lng=13.4&radius=500", false},
-		{"partial bbox — missing max_lat", "min_lng=13.0&min_lat=52.0&max_lng=14.0", false},
-		{"both groups present", "lng=13.4&lat=52.5&radius=500&min_lng=13.0&min_lat=52.0&max_lng=14.0&max_lat=53.0", false},
+		{"empty query", PlacesQueryParams{}, true},
+		{"full proximity group", PlacesQueryParams{Lng: f(13.4), Lat: f(52.5), Radius: f(500)}, true},
+		{"full bbox group", PlacesQueryParams{MinLng: f(13.0), MinLat: f(52.0), MaxLng: f(14.0), MaxLat: f(53.0)}, true},
+		{"partial proximity — missing radius", PlacesQueryParams{Lng: f(13.4), Lat: f(52.5)}, false},
+		{"partial proximity — missing lat", PlacesQueryParams{Lng: f(13.4), Radius: f(500)}, false},
+		{"partial bbox — missing max_lat", PlacesQueryParams{MinLng: f(13.0), MinLat: f(52.0), MaxLng: f(14.0)}, false},
+		{"both groups present", PlacesQueryParams{Lng: f(13.4), Lat: f(52.5), Radius: f(500), MinLng: f(13.0), MinLat: f(52.0), MaxLng: f(14.0), MaxLat: f(53.0)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q, _ := url.ParseQuery(tt.query)
-			errs := PlacesQuery(q)
+			errs := PlacesQuery(tt.params)
 			if (len(errs) == 0) != tt.valid {
-				t.Errorf("query=%q valid=%v, want %v; errs=%+v", tt.query, len(errs) == 0, tt.valid, errs)
+				t.Errorf("params=%+v valid=%v, want %v; errs=%+v", tt.params, len(errs) == 0, tt.valid, errs)
 			}
 		})
 	}
@@ -136,21 +135,22 @@ func TestPlacesQuery_GroupRules(t *testing.T) {
 
 // Bounding-box ordering: min must be strictly less than max.
 func TestPlacesQuery_BBoxOrdering(t *testing.T) {
+	f := ptrFloat
 	t.Run("swapped lng", func(t *testing.T) {
-		q, _ := url.ParseQuery("min_lng=14.0&min_lat=52.0&max_lng=13.0&max_lat=53.0")
-		if !errorsHaveField(PlacesQuery(q), "min_lng") {
+		p := PlacesQueryParams{MinLng: f(14.0), MinLat: f(52.0), MaxLng: f(13.0), MaxLat: f(53.0)}
+		if !errorsHaveField(PlacesQuery(p), "min_lng") {
 			t.Error("expected error when min_lng >= max_lng")
 		}
 	})
 	t.Run("swapped lat", func(t *testing.T) {
-		q, _ := url.ParseQuery("min_lng=13.0&min_lat=53.0&max_lng=14.0&max_lat=52.0")
-		if !errorsHaveField(PlacesQuery(q), "min_lat") {
+		p := PlacesQueryParams{MinLng: f(13.0), MinLat: f(53.0), MaxLng: f(14.0), MaxLat: f(52.0)}
+		if !errorsHaveField(PlacesQuery(p), "min_lat") {
 			t.Error("expected error when min_lat >= max_lat")
 		}
 	})
 	t.Run("valid ordering", func(t *testing.T) {
-		q, _ := url.ParseQuery("min_lng=13.0&min_lat=52.0&max_lng=14.0&max_lat=53.0")
-		if errs := PlacesQuery(q); len(errs) != 0 {
+		p := PlacesQueryParams{MinLng: f(13.0), MinLat: f(52.0), MaxLng: f(14.0), MaxLat: f(53.0)}
+		if errs := PlacesQuery(p); len(errs) != 0 {
 			t.Errorf("expected no errors, got %+v", errs)
 		}
 	})
@@ -162,27 +162,23 @@ func TestPlacesQuery_CursorParam(t *testing.T) {
 	const validID = "11111111-2222-3333-4444-555555555555"
 
 	b64 := func(s string) string { return b64Enc([]byte(s)) }
+	cur := func(s string) *string { return &s }
 
 	tests := []struct {
 		name    string
-		cursor  string
+		cursor  *string
 		wantErr bool
 	}{
-		{"no cursor", "", false},
-		{"invalid base64", "!!!!", true},
-		{"no pipe separator", b64("no-pipe-here"), true},
-		{"bad timestamp", b64("not-a-time|" + validID), true},
-		{"bad uuid", b64(validTS + "|not-a-uuid"), true},
-		{"valid cursor", b64(validTS + "|" + validID), false},
+		{"no cursor", nil, false},
+		{"invalid base64", cur("!!!!"), true},
+		{"no pipe separator", cur(b64("no-pipe-here")), true},
+		{"bad timestamp", cur(b64("not-a-time|" + validID)), true},
+		{"bad uuid", cur(b64(validTS + "|not-a-uuid")), true},
+		{"valid cursor", cur(b64(validTS + "|" + validID)), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rawQuery := ""
-			if tt.cursor != "" {
-				rawQuery = "cursor=" + url.QueryEscape(tt.cursor)
-			}
-			q, _ := url.ParseQuery(rawQuery)
-			errs := PlacesQuery(q)
+			errs := PlacesQuery(PlacesQueryParams{Cursor: tt.cursor})
 			if tt.wantErr && !errorsHaveField(errs, "cursor") {
 				t.Errorf("expected cursor error, got %+v", errs)
 			}


### PR DESCRIPTION
After the OpenAPI migration, `ListPlaces` received typed `ListPlacesParams` (`*float64` fields) from oapi-codegen, but called `buildRawQuery()` to convert them back to strings, which `PlacesQuery` then re-parsed via `strconv.ParseFloat`.

- Add `PlacesQueryParams` struct to the `validation` package with typed `*float64`/`*string` fields
- Rewrite `PlacesQuery` to accept `PlacesQueryParams` directly, removing the `strconv` calls
- Remove `buildRawQuery` from `cmd/api/main.go`
- Update `validation_test.go` to construct `PlacesQueryParams` directly

Closes #49