### PR TITLE
Wire Source registry into cmd/ingestion

### DIFF
--- a/cmd/ingestion/batcher.go
+++ b/cmd/ingestion/batcher.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"context"
+
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// batcher buffers places and flushes in fixed-size batches via flush.
+// It is single-goroutine; cmd/ingestion runs ingestion serially.
+type batcher struct {
+	size    int
+	flush   func(context.Context, []models.Place) error
+	buffer  []models.Place
+	written int
+}
+
+func (b *batcher) sink(ctx context.Context, p models.Place) error {
+	b.buffer = append(b.buffer, p)
+	if len(b.buffer) >= b.size {
+		return b.flushNow(ctx)
+	}
+	return nil
+}
+
+func (b *batcher) flushNow(ctx context.Context) error {
+	if len(b.buffer) == 0 {
+		return nil
+	}
+	if err := b.flush(ctx, b.buffer); err != nil {
+		return err
+	}
+	b.written += len(b.buffer)
+	b.buffer = b.buffer[:0]
+	return nil
+}

--- a/cmd/ingestion/batcher_test.go
+++ b/cmd/ingestion/batcher_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+func TestBatcher_FlushesWhenFull(t *testing.T) {
+	var flushes [][]models.Place
+	b := &batcher{
+		size: 2,
+		flush: func(_ context.Context, batch []models.Place) error {
+			cp := make([]models.Place, len(batch))
+			copy(cp, batch)
+			flushes = append(flushes, cp)
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := b.sink(ctx, models.Place{}); err != nil {
+			t.Fatalf("sink %d: %v", i, err)
+		}
+	}
+
+	if len(flushes) != 1 {
+		t.Fatalf("expected 1 size-triggered flush, got %d", len(flushes))
+	}
+	if len(flushes[0]) != 2 {
+		t.Errorf("expected first flush size 2, got %d", len(flushes[0]))
+	}
+	if b.written != 2 {
+		t.Errorf("written = %d, want 2", b.written)
+	}
+}
+
+func TestBatcher_FlushNow_DrainsPartialBuffer(t *testing.T) {
+	var flushes [][]models.Place
+	b := &batcher{
+		size: 10,
+		flush: func(_ context.Context, batch []models.Place) error {
+			cp := make([]models.Place, len(batch))
+			copy(cp, batch)
+			flushes = append(flushes, cp)
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := b.sink(ctx, models.Place{}); err != nil {
+			t.Fatalf("sink: %v", err)
+		}
+	}
+	if len(flushes) != 0 {
+		t.Fatalf("expected no flushes before flushNow, got %d", len(flushes))
+	}
+
+	if err := b.flushNow(ctx); err != nil {
+		t.Fatalf("flushNow: %v", err)
+	}
+	if len(flushes) != 1 || len(flushes[0]) != 3 {
+		t.Fatalf("expected one flush of size 3, got %v", flushes)
+	}
+	if b.written != 3 {
+		t.Errorf("written = %d, want 3", b.written)
+	}
+}
+
+func TestBatcher_FlushNow_NoOpWhenEmpty(t *testing.T) {
+	called := false
+	b := &batcher{
+		size: 10,
+		flush: func(context.Context, []models.Place) error {
+			called = true
+			return nil
+		},
+	}
+	if err := b.flushNow(context.Background()); err != nil {
+		t.Fatalf("flushNow: %v", err)
+	}
+	if called {
+		t.Error("flush should not be called for empty buffer")
+	}
+}
+
+func TestBatcher_PropagatesFlushError(t *testing.T) {
+	sentinel := errors.New("boom")
+	b := &batcher{
+		size: 1,
+		flush: func(context.Context, []models.Place) error {
+			return sentinel
+		},
+	}
+	err := b.sink(context.Background(), models.Place{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel, got %v", err)
+	}
+}

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/InWheelOrg/inwheel-api/internal/db"
-	"github.com/InWheelOrg/inwheel-api/internal/sources/osm"
 	"github.com/InWheelOrg/inwheel-api/internal/place"
-	"github.com/InWheelOrg/inwheel-api/pkg/models"
+	"github.com/InWheelOrg/inwheel-api/internal/sources"
 )
 
 const batchSize = 1000
@@ -22,10 +22,12 @@ const batchSize = 1000
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: inwheel-ingestion <full-import|diff-sync>")
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: inwheel-ingestion <source> <full-import|diff-sync>")
 		os.Exit(1)
 	}
+	sourceName := os.Args[1]
+	command := os.Args[2]
 
 	cfg, err := loadConfig(environAsMap())
 	if err != nil {
@@ -33,6 +35,8 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("config loaded",
+		"source", sourceName,
+		"command", command,
 		"db.host", cfg.DBHost,
 		"db.port", cfg.DBPort,
 		"db.user", cfg.DBUser,
@@ -41,17 +45,8 @@ func main() {
 		"osm.pbf_path", cfg.OSMPBFPath,
 	)
 
-	switch os.Args[1] {
-	case "full-import":
-		if err := runFullImport(context.Background(), cfg); err != nil {
-			slog.Error("full-import failed", "error", err)
-			os.Exit(1)
-		}
-	case "diff-sync":
-		slog.Error("diff-sync not implemented yet")
-		os.Exit(1)
-	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+	if err := run(context.Background(), sourceName, command, cfg); err != nil {
+		slog.Error("ingestion failed", "source", sourceName, "command", command, "error", err)
 		os.Exit(1)
 	}
 }
@@ -69,7 +64,12 @@ func environAsMap() map[string]string {
 	return out
 }
 
-func runFullImport(ctx context.Context, cfg config) error {
+func run(ctx context.Context, sourceName, command string, cfg config) error {
+	src, err := buildSource(sourceName, cfg)
+	if err != nil {
+		return err
+	}
+
 	gormDB, err := db.Connect(db.Config{
 		Host:     cfg.DBHost,
 		Port:     cfg.DBPort,
@@ -86,62 +86,39 @@ func runFullImport(ctx context.Context, cfg config) error {
 	}
 
 	repo := place.NewRepository(gormDB)
+	b := &batcher{size: batchSize, flush: repo.UpsertBatch}
 
-	f, err := os.Open(cfg.OSMPBFPath)
-	if err != nil {
-		return fmt.Errorf("open pbf: %w", err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	var (
-		buffer    []models.Place
-		processed int
-		written   int
-	)
-
-	flush := func() error {
-		if len(buffer) == 0 {
-			return nil
-		}
-		if err := repo.UpsertBatch(ctx, buffer); err != nil {
-			return err
-		}
-		written += len(buffer)
-		buffer = buffer[:0]
-		return nil
+	if err := dispatch(ctx, src, command, b.sink); err != nil {
+		return fmt.Errorf("source %q: %w", src.Name(), err)
 	}
 
-	err = osm.StreamNodes(ctx, f, func(node osm.Node) error {
-		processed++
-		if processed%10000 == 0 {
-			slog.Info("progress", "processed", processed, "written", written)
-		}
-
-		category, ok := osm.Evaluate(node.Tags)
-		if !ok {
-			return nil
-		}
-
-		p, err := osm.TransformNode(node.ID, node.Lat, node.Lng, node.Tags, category)
-		if err != nil {
-			slog.Warn("skipping node, transform error", "node_id", node.ID, "error", err)
-			return nil
-		}
-
-		buffer = append(buffer, *p)
-		if len(buffer) >= batchSize {
-			return flush()
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("stream: %w", err)
-	}
-
-	if err := flush(); err != nil {
+	if err := b.flushNow(ctx); err != nil {
 		return fmt.Errorf("final flush: %w", err)
 	}
 
-	slog.Info("full-import complete", "processed", processed, "written", written)
+	slog.Info("ingestion complete",
+		"source", src.Name(),
+		"command", command,
+		"written", b.written,
+	)
 	return nil
+}
+
+func dispatch(ctx context.Context, src sources.Source, command string, sink sources.Sink) error {
+	switch command {
+	case "full-import":
+		fi, ok := src.(sources.FullImporter)
+		if !ok {
+			return fmt.Errorf("source %q does not support full-import", src.Name())
+		}
+		return fi.FullImport(ctx, sink)
+	case "diff-sync":
+		ds, ok := src.(sources.DiffSyncer)
+		if !ok {
+			return fmt.Errorf("source %q does not support diff-sync", src.Name())
+		}
+		return ds.DiffSync(ctx, time.Time{}, sink)
+	default:
+		return fmt.Errorf("unknown command: %q", command)
+	}
 }

--- a/cmd/ingestion/main_integration_test.go
+++ b/cmd/ingestion/main_integration_test.go
@@ -33,8 +33,8 @@ func TestRunFullImport_AgainstFixturePBF(t *testing.T) {
 		OSMPBFPath: "../../testdata/andorra-sample.osm.pbf",
 	}
 
-	if err := runFullImport(ctx, cfg); err != nil {
-		t.Fatalf("runFullImport: %v", err)
+	if err := run(ctx, "osm", "full-import", cfg); err != nil {
+		t.Fatalf("run: %v", err)
 	}
 
 	var count int64

--- a/cmd/ingestion/registry.go
+++ b/cmd/ingestion/registry.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/InWheelOrg/inwheel-api/internal/sources"
+	"github.com/InWheelOrg/inwheel-api/internal/sources/osm"
+)
+
+// buildSource returns the concrete sources.Source for the given name,
+// constructed from cfg. Unknown names and missing source-specific config
+// produce an error.
+func buildSource(name string, cfg config) (sources.Source, error) {
+	switch name {
+	case "osm":
+		if cfg.OSMPBFPath == "" {
+			return nil, fmt.Errorf("source %q requires OSM_PBF_PATH", name)
+		}
+		return &osm.Source{PBFPath: cfg.OSMPBFPath}, nil
+	default:
+		return nil, fmt.Errorf("unknown source: %q", name)
+	}
+}

--- a/cmd/ingestion/registry_test.go
+++ b/cmd/ingestion/registry_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/internal/sources/osm"
+)
+
+func TestBuildSource_OSMHappyPath(t *testing.T) {
+	cfg := config{OSMPBFPath: "/tmp/x.pbf"}
+	src, err := buildSource("osm", cfg)
+	if err != nil {
+		t.Fatalf("buildSource: %v", err)
+	}
+	got, ok := src.(*osm.Source)
+	if !ok {
+		t.Fatalf("expected *osm.Source, got %T", src)
+	}
+	if got.PBFPath != "/tmp/x.pbf" {
+		t.Errorf("PBFPath = %q, want %q", got.PBFPath, "/tmp/x.pbf")
+	}
+}
+
+func TestBuildSource_OSMMissingConfig(t *testing.T) {
+	_, err := buildSource("osm", config{})
+	if err == nil {
+		t.Fatal("expected error for missing OSM_PBF_PATH, got nil")
+	}
+	if !strings.Contains(err.Error(), "OSM_PBF_PATH") {
+		t.Errorf("error should mention OSM_PBF_PATH, got %v", err)
+	}
+}
+
+func TestBuildSource_UnknownSource(t *testing.T) {
+	_, err := buildSource("wheelmap", config{})
+	if err == nil {
+		t.Fatal("expected error for unknown source, got nil")
+	}
+	if !strings.Contains(err.Error(), "wheelmap") {
+		t.Errorf("error should name the source, got %v", err)
+	}
+}


### PR DESCRIPTION
Second half of #60, building on #65. Replaces the OSM-specific pipeline in `cmd/ingestion/main.go` with a registry + capability-interface dispatch.

## Summary

- Adds `cmd/ingestion/batcher.go` — small `batcher` type wrapping `repo.UpsertBatch` with fixed-size buffering. Sources don't know about batching.
- Adds `cmd/ingestion/registry.go` — `buildSource(name, cfg)` maps a source name to a constructed concrete source. Single switch today, mechanical to extend.
- Rewrites `cmd/ingestion/main.go`: CLI shape becomes `inwheel-ingestion <source> <command>`. Dispatch type-asserts to `sources.FullImporter` or `sources.DiffSyncer` and returns a descriptive error if the source doesn't support the requested mode.
- Updates the integration test to the new CLI shape.

`internal/sources/osm` is unchanged here — it was introduced in #65.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all unit tests pass (new batcher + registry tests, existing OSM tests)
- [x] `go test -tags integration -timeout 120s ./cmd/ingestion/...` — Andorra fixture imported end-to-end via the new dispatch

Closes #60.