### PR TITLE
Deepen full-import integration coverage

### DIFF
--- a/cmd/ingestion/main_integration_test.go
+++ b/cmd/ingestion/main_integration_test.go
@@ -9,13 +9,78 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/InWheelOrg/inwheel-api/internal/testhelpers"
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
 )
 
-func TestRunFullImport_AgainstFixturePBF(t *testing.T) {
+const fixturePBFPath = "../../testdata/andorra-sample.osm.pbf"
+
+// expectedPOICount is the number of nodes in the Andorra fixture that pass
+// osm.Evaluate. Locked in by inspecting the fixture; if the filter rules
+// change or the fixture is replaced, this number must be updated.
+const expectedPOICount = 976
+
+// pinned is a known POI from the Andorra fixture used to verify that the
+// transform → upsert pipeline produces the expected place row.
+type pinned struct {
+	osmID     int64
+	name      string
+	category  models.Category
+	rank      models.Rank
+	lat       float64
+	lng       float64
+	tagSubset map[string]string
+}
+
+var pinnedPOIs = []pinned{
+	{
+		osmID:    521143390,
+		name:     "Supermercat Saint Moritz",
+		category: models.CategoryShop,
+		rank:     models.RankEstablishment,
+		lat:      42.571637,
+		lng:      1.484545,
+		tagSubset: map[string]string{
+			"shop":             "supermarket",
+			"name":             "Supermercat Saint Moritz",
+			"addr:city":        "Arinsal",
+			"addr:street":      "Carretera d'Arinsal",
+			"addr:housenumber": "16",
+		},
+	},
+	{
+		osmID:    690708548,
+		name:     "Farmàcia del Pas",
+		category: models.CategoryHealthcare,
+		rank:     models.RankEstablishment,
+		lat:      42.542391,
+		lng:      1.733906,
+		tagSubset: map[string]string{
+			"amenity":    "pharmacy",
+			"healthcare": "pharmacy",
+			"name":       "Farmàcia del Pas",
+		},
+	},
+	{
+		osmID:    323129883,
+		name:     "Telecabina La Massana",
+		category: models.CategoryTransport,
+		rank:     models.RankLandmark, // public_transport=station promotes transport to landmark
+		lat:      42.547295,
+		lng:      1.513858,
+		tagSubset: map[string]string{
+			"public_transport": "station",
+			"aerialway":        "station",
+			"name":             "Telecabina La Massana",
+		},
+	},
+}
+
+func TestFullImport_AndorraFixture(t *testing.T) {
 	ctx := context.Background()
 	db, connInfo, cleanup, err := testhelpers.StartPostgresWithConnInfo(ctx)
 	if err != nil {
@@ -30,19 +95,78 @@ func TestRunFullImport_AgainstFixturePBF(t *testing.T) {
 		DBPassword: connInfo.Password,
 		DBName:     connInfo.Name,
 		DBSSLMode:  connInfo.SSLMode,
-		OSMPBFPath: "../../testdata/andorra-sample.osm.pbf",
+		OSMPBFPath: fixturePBFPath,
 	}
 
 	if err := run(ctx, "osm", "full-import", cfg); err != nil {
-		t.Fatalf("run: %v", err)
+		t.Fatalf("first import: %v", err)
 	}
 
-	var count int64
-	if err := db.Model(&models.Place{}).Count(&count).Error; err != nil {
-		t.Fatalf("count: %v", err)
+	t.Run("imports the expected POI count", func(t *testing.T) {
+		var count int64
+		if err := db.Model(&models.Place{}).Count(&count).Error; err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if count != expectedPOICount {
+			t.Errorf("imported %d places, want %d", count, expectedPOICount)
+		}
+	})
+
+	for _, p := range pinnedPOIs {
+		t.Run("pinned/"+p.name, func(t *testing.T) {
+			var got models.Place
+			err := db.Where("osm_id = ? AND osm_type = ?", p.osmID, models.OSMNode).First(&got).Error
+			if err != nil {
+				t.Fatalf("lookup osm_id=%d: %v", p.osmID, err)
+			}
+
+			if got.Name != p.name {
+				t.Errorf("name = %q, want %q", got.Name, p.name)
+			}
+			if got.Category != p.category {
+				t.Errorf("category = %q, want %q", got.Category, p.category)
+			}
+			if got.Rank != p.rank {
+				t.Errorf("rank = %d, want %d", got.Rank, p.rank)
+			}
+			if math.Abs(got.Lat-p.lat) > 1e-5 {
+				t.Errorf("lat = %f, want ~%f", got.Lat, p.lat)
+			}
+			if math.Abs(got.Lng-p.lng) > 1e-5 {
+				t.Errorf("lng = %f, want ~%f", got.Lng, p.lng)
+			}
+			if got.Source != "osm" {
+				t.Errorf("source = %q, want %q", got.Source, "osm")
+			}
+			if got.Status != models.PlaceStatusActive {
+				t.Errorf("status = %q, want %q", got.Status, models.PlaceStatusActive)
+			}
+			wantExternalID := fmt.Sprintf("node/%d", p.osmID)
+			if got.ExternalIDs["osm"] != wantExternalID {
+				t.Errorf("external_ids[osm] = %q, want %q", got.ExternalIDs["osm"], wantExternalID)
+			}
+			for k, v := range p.tagSubset {
+				if got.Tags[k] != v {
+					t.Errorf("tags[%q] = %q, want %q", k, got.Tags[k], v)
+				}
+			}
+		})
 	}
-	t.Logf("imported %d places from the Andorra fixture", count)
-	if count == 0 {
-		t.Fatal("expected at least one place row, got zero")
-	}
+
+	t.Run("re-import is idempotent on row count", func(t *testing.T) {
+		var before int64
+		if err := db.Model(&models.Place{}).Count(&before).Error; err != nil {
+			t.Fatalf("count before: %v", err)
+		}
+		if err := run(ctx, "osm", "full-import", cfg); err != nil {
+			t.Fatalf("second import: %v", err)
+		}
+		var after int64
+		if err := db.Model(&models.Place{}).Count(&after).Error; err != nil {
+			t.Fatalf("count after: %v", err)
+		}
+		if after != before {
+			t.Errorf("row count changed across re-import: before=%d after=%d", before, after)
+		}
+	})
 }

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,0 +1,18 @@
+# Test fixtures
+
+## `andorra-sample.osm.pbf`
+
+A small extract of OpenStreetMap data covering Andorra, used by
+`cmd/ingestion`'s integration test (`go test -tags integration ./cmd/ingestion/...`)
+to verify the full-import pipeline against a real Postgres/PostGIS container.
+
+### Attribution and license
+
+OpenStreetMap data, including this extract, is © OpenStreetMap contributors
+and licensed under the [Open Database License (ODbL) 1.0](https://opendatacommons.org/licenses/odbl/1-0/).
+
+See https://www.openstreetmap.org/copyright for full attribution requirements.
+
+The ODbL governs only the contents of `.osm.pbf` files in this directory.
+The surrounding source code is licensed under AGPL-3.0 — see `LICENSE`
+at the repository root.


### PR DESCRIPTION
## Summary

Replaces the existing one-assertion smoke test in `cmd/ingestion/main_integration_test.go` with a deeper end-to-end check against a real Postgres/PostGIS container.

The new `TestFullImport_AndorraFixture` runs `full-import` once against the Andorra fixture, then runs four subtests sharing the same DB:

- **POI count** — asserts exactly 976 places land after filtering (the count `osm.Evaluate` accepts from the fixture; locked in as a constant).
- **Pinned POIs** — three real Andorra nodes (a supermarket, a pharmacy, a cable-car station) verify category, rank, lat/lng, source, status, external_ids, and a tag subset. The cable-car station also exercises the `public_transport=station → RankLandmark` path.
- **Idempotency** — re-runs the import, asserts the row count is unchanged. Exercises the `(osm_id, osm_type)` upsert conflict key.

Subtests share the testcontainer lifecycle so the Postgres startup cost (~5s) is paid once per `go test` invocation rather than per assertion.

Also adds `testdata/README.md` documenting ODbL attribution for the Andorra fixture, separating it from the surrounding AGPL-3.0 code.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` — unit tests unchanged, all pass
- [x] `go test -tags integration -timeout 120s ./cmd/ingestion/...` — passes locally in ~14s (mostly container startup); all 5 subtests green

Closes #64.