### PR TITLE
Add unmatched_external queue table

### DIFF
--- a/internal/db/migrations/000006_add_external_ids_and_place_status.down.sql
+++ b/internal/db/migrations/000006_add_external_ids_and_place_status.down.sql
@@ -1,3 +1,6 @@
+DROP INDEX IF EXISTS unmatched_external_geom_idx;
+DROP TABLE IF EXISTS unmatched_external;
+
 DROP INDEX IF EXISTS idx_places_external_ids;
 
 ALTER TABLE places

--- a/internal/db/migrations/000006_add_external_ids_and_place_status.up.sql
+++ b/internal/db/migrations/000006_add_external_ids_and_place_status.up.sql
@@ -8,3 +8,18 @@ CREATE INDEX idx_places_external_ids ON places USING GIN (external_ids);
 
 ALTER TABLE accessibility_profiles
     ADD COLUMN user_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE unmatched_external (
+    id             BIGSERIAL        PRIMARY KEY,
+    source         TEXT             NOT NULL,
+    source_id      TEXT             NOT NULL,
+    payload        JSONB            NOT NULL,
+    lat            DOUBLE PRECISION NOT NULL,
+    lng            DOUBLE PRECISION NOT NULL,
+    geom           GEOGRAPHY(POINT, 4326) NOT NULL,
+    last_attempted TIMESTAMPTZ      NOT NULL,
+    attempts       INT              NOT NULL DEFAULT 1,
+    UNIQUE (source, source_id)
+);
+
+CREATE INDEX unmatched_external_geom_idx ON unmatched_external USING GIST (geom);

--- a/internal/db/migrations/000006_add_external_ids_and_place_status.up.sql
+++ b/internal/db/migrations/000006_add_external_ids_and_place_status.up.sql
@@ -17,7 +17,7 @@ CREATE TABLE unmatched_external (
     lat            DOUBLE PRECISION NOT NULL,
     lng            DOUBLE PRECISION NOT NULL,
     geom           GEOGRAPHY(POINT, 4326) NOT NULL,
-    last_attempted TIMESTAMPTZ      NOT NULL,
+    last_attempted TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
     attempts       INT              NOT NULL DEFAULT 1,
     UNIQUE (source, source_id)
 );

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -106,3 +106,62 @@ func TestUpsertBatch_EmptySliceIsNoOp(t *testing.T) {
 		t.Fatalf("empty batch should be a no-op, got error: %v", err)
 	}
 }
+
+func TestUnmatchedExternal_TableRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom, last_attempted)
+		VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326), NOW())
+	`, "wheelmap", "wm/456", `{"name":"Test Cafe","category":"cafe"}`, 60.1699, 24.9384)
+	if err != nil {
+		t.Fatalf("insert into unmatched_external: %v", err)
+	}
+
+	var count int
+	row := sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+		"wheelmap", "wm/456",
+	)
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+func TestUnmatchedExternal_UniqueConstraint(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	sqlDB, _ := db.DB()
+	insert := func() error {
+		_, err := sqlDB.ExecContext(ctx, `
+			INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom, last_attempted)
+			VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326), NOW())
+		`, "wheelmap", "wm/999", `{}`, 60.0, 25.0)
+		return err
+	}
+
+	if err := insert(); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if err := insert(); err == nil {
+		t.Error("second insert with same (source, source_id) should fail the UNIQUE constraint, got nil error")
+	}
+}

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -121,8 +121,8 @@ func TestUnmatchedExternal_TableRoundTrip(t *testing.T) {
 	}
 
 	_, err = sqlDB.ExecContext(ctx, `
-		INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom, last_attempted)
-		VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326), NOW())
+		INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom)
+		VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326))
 	`, "wheelmap", "wm/456", `{"name":"Test Cafe","category":"cafe"}`, 60.1699, 24.9384)
 	if err != nil {
 		t.Fatalf("insert into unmatched_external: %v", err)
@@ -139,6 +139,22 @@ func TestUnmatchedExternal_TableRoundTrip(t *testing.T) {
 	if count != 1 {
 		t.Errorf("count = %d, want 1", count)
 	}
+
+	// Verify geometry is stored with correct coordinate order (lng=X, lat=Y).
+	var storedLng, storedLat float64
+	geomRow := sqlDB.QueryRowContext(ctx,
+		"SELECT ST_X(geom::geometry), ST_Y(geom::geometry) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+		"wheelmap", "wm/456",
+	)
+	if err := geomRow.Scan(&storedLng, &storedLat); err != nil {
+		t.Fatalf("geom query: %v", err)
+	}
+	if storedLng < 24.938 || storedLng > 24.939 {
+		t.Errorf("geom X (lng) = %v, want ~24.9384", storedLng)
+	}
+	if storedLat < 60.169 || storedLat > 60.171 {
+		t.Errorf("geom Y (lat) = %v, want ~60.1699", storedLat)
+	}
 }
 
 func TestUnmatchedExternal_UniqueConstraint(t *testing.T) {
@@ -149,11 +165,14 @@ func TestUnmatchedExternal_UniqueConstraint(t *testing.T) {
 	}
 	defer cleanup()
 
-	sqlDB, _ := db.DB()
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
 	insert := func() error {
 		_, err := sqlDB.ExecContext(ctx, `
-			INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom, last_attempted)
-			VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326), NOW())
+			INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom)
+			VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326))
 		`, "wheelmap", "wm/999", `{}`, 60.0, 25.0)
 		return err
 	}

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -184,3 +184,96 @@ func TestUnmatchedExternal_UniqueConstraint(t *testing.T) {
 		t.Error("second insert with same (source, source_id) should fail the UNIQUE constraint, got nil error")
 	}
 }
+
+func TestUnmatchedExternal_ColumnDefaults(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom)
+		VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326))
+	`, "wheelmap", "wm/defaults", `{}`, 60.0, 25.0)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var attempts int
+	var lastAttempted *string // non-null check via nullable scan
+	row := sqlDB.QueryRowContext(ctx,
+		"SELECT attempts, last_attempted::text FROM unmatched_external WHERE source = $1 AND source_id = $2",
+		"wheelmap", "wm/defaults",
+	)
+	if err := row.Scan(&attempts, &lastAttempted); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+	if lastAttempted == nil {
+		t.Error("last_attempted is NULL, want a timestamp from DEFAULT NOW()")
+	}
+}
+
+func TestUnmatchedExternal_SpatialQuery(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+
+	// Vevey, Switzerland — two records with a clear distance separation.
+	// near: 46.4628, 6.8417 (Grand-Place)
+	// far:  46.4608, 6.8417 (~222 m south — well outside a 50 m radius)
+	insert := func(sourceID string, lat, lng float64) {
+		_, err := sqlDB.ExecContext(ctx, `
+			INSERT INTO unmatched_external (source, source_id, payload, lat, lng, geom)
+			VALUES ($1, $2, $3, $4, $5, ST_SetSRID(ST_MakePoint($5, $4), 4326))
+		`, "wheelmap", sourceID, `{}`, lat, lng)
+		if err != nil {
+			t.Fatalf("insert %s: %v", sourceID, err)
+		}
+	}
+	insert("near", 46.4628, 6.8417)
+	insert("far", 46.4608, 6.8417)
+
+	// Query within 50 m of the near point — should return only "near".
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT source_id FROM unmatched_external
+		WHERE ST_DWithin(geom, ST_SetSRID(ST_MakePoint(6.8417, 46.4628), 4326)::geography, 50)
+	`)
+	if err != nil {
+		t.Fatalf("ST_DWithin query: %v", err)
+	}
+	defer rows.Close()
+
+	var found []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		found = append(found, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	if len(found) != 1 || found[0] != "near" {
+		t.Errorf("ST_DWithin(50m) returned %v, want [near]", found)
+	}
+}


### PR DESCRIPTION
Adds the `unmatched_external` queue table to migration 000006 (edited in place — pre-prod, no data to preserve). This table holds non-OSM records that couldn't be matched to an existing OSM-anchored place at ingest time and are queued for retry after the next OSM ingest of the region.

## Schema

- `BIGSERIAL` surrogate key, `TEXT` source + source_id with a `UNIQUE` constraint
- `JSONB` payload for the raw incoming record
- `lat`/`lng` scalars for cheap reads without PostGIS
- `GEOGRAPHY(POINT, 4326)` geom column with a GIST index for `ST_DWithin` proximity queries
- `TIMESTAMPTZ DEFAULT NOW()` for last_attempted, `INT DEFAULT 1` for attempts

## Tests

Two integration tests in `internal/place/`:
- `TestUnmatchedExternal_TableRoundTrip` — inserts a row, verifies count, and reads back the stored geometry coordinates to confirm `ST_MakePoint(lng, lat)` argument order
- `TestUnmatchedExternal_UniqueConstraint` — verifies a duplicate `(source, source_id)` insert is rejected

Closes #69