### PR TITLE
Identity-resolution matcher and CandidateRepo lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/paulmach/osm v0.9.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	golang.org/x/text v0.36.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.0
@@ -92,6 +93,5 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )

--- a/internal/identity/compat.go
+++ b/internal/identity/compat.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+import (
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// compat is the starter category-compatibility allowlist.
+var compat = map[models.Category]map[models.Category]bool{
+	models.CategoryCafe:       {models.CategoryCafe: true, models.CategoryRestaurant: true, models.CategoryBar: true},
+	models.CategoryRestaurant: {models.CategoryRestaurant: true, models.CategoryCafe: true, models.CategoryBar: true},
+	models.CategoryBar:        {models.CategoryBar: true, models.CategoryRestaurant: true, models.CategoryCafe: true},
+	models.CategoryShop:       {models.CategoryShop: true},
+	models.CategoryHealthcare: {models.CategoryHealthcare: true},
+}
+
+// Compatible returns the candidate categories that an incoming record of
+// category c may match against.
+func Compatible(c models.Category) []models.Category {
+	return nil
+}

--- a/internal/identity/compat.go
+++ b/internal/identity/compat.go
@@ -6,6 +6,8 @@
 package identity
 
 import (
+	"sort"
+
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
 )
 
@@ -21,5 +23,14 @@ var compat = map[models.Category]map[models.Category]bool{
 // Compatible returns the candidate categories that an incoming record of
 // category c may match against.
 func Compatible(c models.Category) []models.Category {
-	return nil
+	set, ok := compat[c]
+	if !ok {
+		return []models.Category{c}
+	}
+	out := make([]models.Category, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }

--- a/internal/identity/compat_test.go
+++ b/internal/identity/compat_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+func TestCompatible(t *testing.T) {
+	cases := []struct {
+		name string
+		in   models.Category
+		want []models.Category
+	}{
+		{
+			name: "cafe maps to food/drink cluster, sorted",
+			in:   models.CategoryCafe,
+			want: []models.Category{models.CategoryBar, models.CategoryCafe, models.CategoryRestaurant},
+		},
+		{
+			name: "restaurant maps to food/drink cluster, sorted",
+			in:   models.CategoryRestaurant,
+			want: []models.Category{models.CategoryBar, models.CategoryCafe, models.CategoryRestaurant},
+		},
+		{
+			name: "shop maps to self only",
+			in:   models.CategoryShop,
+			want: []models.Category{models.CategoryShop},
+		},
+		{
+			name: "healthcare maps to self only",
+			in:   models.CategoryHealthcare,
+			want: []models.Category{models.CategoryHealthcare},
+		},
+		{
+			name: "category not in map returns self only",
+			in:   models.CategoryMall,
+			want: []models.Category{models.CategoryMall},
+		},
+		{
+			name: "empty category returns self only",
+			in:   "",
+			want: []models.Category{""},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := identity.Compatible(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Compatible(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/identity/decision.go
+++ b/internal/identity/decision.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+// Kind discriminates a Decision's outcome.
+type Kind int
+
+const (
+	// KindConfident means the matcher found a place with score >= ConfidentThreshold.
+	KindConfident Kind = iota
+	// KindLowConfidence means the best score was in [LowConfidenceThreshold, ConfidentThreshold).
+	KindLowConfidence
+	// KindNoMatch means no candidate scored at or above LowConfidenceThreshold.
+	KindNoMatch
+)
+
+// String returns a stable lowercase tag for logs and metrics.
+func (k Kind) String() string {
+	switch k {
+	case KindConfident:
+		return "confident"
+	case KindLowConfidence:
+		return "low_confidence"
+	case KindNoMatch:
+		return "no_match"
+	default:
+		return "unknown"
+	}
+}
+
+// Decision is the matcher's answer for one Record.
+type Decision struct {
+	// Kind is the outcome category.
+	Kind Kind
+	// MatchedPlaceID is the chosen place's ID. Empty when Kind == KindNoMatch.
+	MatchedPlaceID string
+	// Confidence is the best candidate's score in [0, 1]. Zero when Kind == KindNoMatch.
+	Confidence float64
+}

--- a/internal/identity/decision.go
+++ b/internal/identity/decision.go
@@ -9,12 +9,13 @@ package identity
 type Kind int
 
 const (
-	// KindConfident means the matcher found a place with score >= ConfidentThreshold.
-	KindConfident Kind = iota
+	// KindNoMatch is the zero value, returned on errors and when no candidate
+	// scored at or above LowConfidenceThreshold.
+	KindNoMatch Kind = iota
 	// KindLowConfidence means the best score was in [LowConfidenceThreshold, ConfidentThreshold).
 	KindLowConfidence
-	// KindNoMatch means no candidate scored at or above LowConfidenceThreshold.
-	KindNoMatch
+	// KindConfident means the matcher found a place with score >= ConfidentThreshold.
+	KindConfident
 )
 
 // String returns a stable lowercase tag for logs and metrics.

--- a/internal/identity/doc.go
+++ b/internal/identity/doc.go
@@ -26,12 +26,12 @@
 //
 //     - distance: linear falloff, 1.0 at 0 m, 0.0 at 50 m.
 //     - name:     token-set Jaccard over normalized words. "Café Pascal"
-//                 and "PASCAL CAFE." normalize to the same tokens.
+//     and "PASCAL CAFE." normalize to the same tokens.
 //     - address:  1.0 if street + house number match, 0.5 if street only,
-//                 0.0 otherwise. If either side lacks an address the
-//                 signal is dropped and its weight is redistributed
-//                 proportionally between distance and name (final score
-//                 still in [0, 1]).
+//     0.0 otherwise. If either side lacks an address the
+//     signal is dropped and its weight is redistributed
+//     proportionally between distance and name (final score
+//     still in [0, 1]).
 //
 //     Weighted sum: 0.5*distance + 0.4*name + 0.1*address.
 //

--- a/internal/identity/doc.go
+++ b/internal/identity/doc.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Package identity resolves whether an incoming non-OSM record refers to an
+// existing OSM-anchored place in the places table, or whether no acceptable
+// match exists.
+//
+// # The problem
+//
+// Wheelmap and future similar sources describe accessibility of physical
+// places, identified by their own ID. To attach that accessibility data to
+// the right row in the places table, the package decides which existing
+// place an incoming record refers to, or that none of them do.
+//
+// # The algorithm
+//
+//  1. Candidate fetch: ask the repo for active places within 50 m whose
+//     category is compatible with the incoming record's category. Category
+//     compatibility is an allowlist: a cafe can match a restaurant; a cafe
+//     cannot match a pharmacy. This hard filter eliminates the worst class
+//     of wrong matches cheaply.
+//
+//  2. Score each candidate in [0, 1] from three signals:
+//
+//     - distance: linear falloff, 1.0 at 0 m, 0.0 at 50 m.
+//     - name:     token-set Jaccard over normalized words. "Café Pascal"
+//                 and "PASCAL CAFE." normalize to the same tokens.
+//     - address:  1.0 if street + house number match, 0.5 if street only,
+//                 0.0 otherwise. If either side lacks an address the
+//                 signal is dropped and its weight is redistributed
+//                 proportionally between distance and name (final score
+//                 still in [0, 1]).
+//
+//     Weighted sum: 0.5*distance + 0.4*name + 0.1*address.
+//
+//  3. Decide on the best candidate's score:
+//
+//     - >= 0.80 -> Confident       (attach to that place)
+//     - >= 0.55 -> LowConfidence   (attach, but record the low score)
+//     - <  0.55 -> NoMatch         (enqueue in unmatched_external)
+//
+// # What this package does not do
+//
+//   - Persist anything. Match returns a Decision; callers do the writes.
+//   - Talk to any upstream source. Callers shape rows into identity.Record.
+//   - Tune thresholds at runtime. Constants in score.go are reviewed in PRs
+//     against a fixture set so behaviour drift is visible at review time.
+package identity

--- a/internal/identity/matcher.go
+++ b/internal/identity/matcher.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+import (
+	"context"
+
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// CandidateRepo is the only I/O surface Match touches: a spatial + category
+// query against the places table.
+type CandidateRepo interface {
+	// FindCandidates returns active places within radiusM metres of (lat, lng)
+	// whose category is in categories.
+	FindCandidates(ctx context.Context, lat, lng, radiusM float64, categories []models.Category) ([]models.Place, error)
+}
+
+// Match decides whether r refers to an existing place in the registry.
+// Returns a Decision describing the outcome and a non-nil error only when
+// the repository call fails.
+func Match(ctx context.Context, repo CandidateRepo, r Record) (Decision, error) {
+	return Decision{}, nil
+}

--- a/internal/identity/matcher.go
+++ b/internal/identity/matcher.go
@@ -7,21 +7,54 @@ package identity
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
 )
 
-// CandidateRepo is the only I/O surface Match touches: a spatial + category
-// query against the places table.
+// CandidateRepo is the only I/O surface Match touches.
 type CandidateRepo interface {
-	// FindCandidates returns active places within radiusM metres of (lat, lng)
-	// whose category is in categories.
 	FindCandidates(ctx context.Context, lat, lng, radiusM float64, categories []models.Category) ([]models.Place, error)
 }
 
 // Match decides whether r refers to an existing place in the registry.
-// Returns a Decision describing the outcome and a non-nil error only when
-// the repository call fails.
 func Match(ctx context.Context, repo CandidateRepo, r Record) (Decision, error) {
-	return Decision{}, nil
+	cats := Compatible(r.Category)
+	candidates, err := repo.FindCandidates(ctx, r.Lat, r.Lng, RadiusM, cats)
+	if err != nil {
+		return Decision{}, fmt.Errorf("find candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return Decision{Kind: KindNoMatch}, nil
+	}
+
+	bestIdx := -1
+	bestScore := -1.0
+	for i, c := range candidates {
+		score := scoreCandidate(r, c)
+		if score > bestScore {
+			bestScore = score
+			bestIdx = i
+		}
+	}
+
+	switch {
+	case bestScore >= ConfidentThreshold:
+		return Decision{Kind: KindConfident, MatchedPlaceID: candidates[bestIdx].ID, Confidence: bestScore}, nil
+	case bestScore >= LowConfidenceThreshold:
+		return Decision{Kind: KindLowConfidence, MatchedPlaceID: candidates[bestIdx].ID, Confidence: bestScore}, nil
+	default:
+		return Decision{Kind: KindNoMatch}, nil
+	}
+}
+
+// scoreCandidate combines the three score components for a single candidate.
+// Address lookups come from OSM tags addr:street and addr:housenumber.
+func scoreCandidate(r Record, p models.Place) float64 {
+	dist := distanceScore(r.Lat, r.Lng, p.Lat, p.Lng)
+	name := nameScore(r.Name, p.Name)
+	pStreet := p.Tags["addr:street"]
+	pHouse := p.Tags["addr:housenumber"]
+	addr, present := addressScore(r.Street, r.HouseNumber, pStreet, pHouse)
+	return combinedScore(dist, name, addr, present)
 }

--- a/internal/identity/matcher_test.go
+++ b/internal/identity/matcher_test.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// fakeRepo returns a fixed candidate slice and records the categories it was
+// called with so tests can assert the compat-filter was applied.
+type fakeRepo struct {
+	candidates []models.Place
+	err        error
+	lastCats   []models.Category
+}
+
+func (f *fakeRepo) FindCandidates(_ context.Context, _, _, _ float64, cats []models.Category) ([]models.Place, error) {
+	f.lastCats = cats
+	return f.candidates, f.err
+}
+
+func TestMatch_NoCandidatesReturnsNoMatch(t *testing.T) {
+	repo := &fakeRepo{candidates: nil}
+	r := identity.Record{
+		Name:     "Pascal",
+		Lat:      60.1699,
+		Lng:      24.9384,
+		Category: models.CategoryCafe,
+	}
+	d, err := identity.Match(context.Background(), repo, r)
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if d.Kind != identity.KindNoMatch {
+		t.Errorf("Kind = %v, want KindNoMatch", d.Kind)
+	}
+	if d.MatchedPlaceID != "" {
+		t.Errorf("MatchedPlaceID = %q, want empty", d.MatchedPlaceID)
+	}
+	if d.Confidence != 0 {
+		t.Errorf("Confidence = %v, want 0", d.Confidence)
+	}
+}
+
+func TestMatch_PassesCompatibleCategoriesToRepo(t *testing.T) {
+	repo := &fakeRepo{candidates: nil}
+	r := identity.Record{
+		Name:     "Pascal",
+		Lat:      60.1699,
+		Lng:      24.9384,
+		Category: models.CategoryCafe,
+	}
+	if _, err := identity.Match(context.Background(), repo, r); err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	want := []models.Category{models.CategoryBar, models.CategoryCafe, models.CategoryRestaurant}
+	if len(repo.lastCats) != len(want) {
+		t.Fatalf("lastCats = %v, want %v", repo.lastCats, want)
+	}
+	for i := range want {
+		if repo.lastCats[i] != want[i] {
+			t.Errorf("lastCats[%d] = %q, want %q", i, repo.lastCats[i], want[i])
+		}
+	}
+}
+
+func TestMatch_PropagatesRepoError(t *testing.T) {
+	wantErr := errors.New("db down")
+	repo := &fakeRepo{err: wantErr}
+	r := identity.Record{Lat: 60, Lng: 24, Category: models.CategoryCafe}
+	_, err := identity.Match(context.Background(), repo, r)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestMatch_ConfidentAttachOnHighScore(t *testing.T) {
+	// Coincident point, identical name, matching address → score = 1.0
+	repo := &fakeRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe,
+			Tags: models.PlaceTags{"addr:street": "Mannerheimintie", "addr:housenumber": "10"}},
+	}}
+	r := identity.Record{
+		Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe,
+		Street: "Mannerheimintie", HouseNumber: "10",
+	}
+	d, err := identity.Match(context.Background(), repo, r)
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if d.Kind != identity.KindConfident {
+		t.Errorf("Kind = %v, want KindConfident", d.Kind)
+	}
+	if d.MatchedPlaceID != "p1" {
+		t.Errorf("MatchedPlaceID = %q, want %q", d.MatchedPlaceID, "p1")
+	}
+	if d.Confidence < 0.99 {
+		t.Errorf("Confidence = %v, want >= 0.99", d.Confidence)
+	}
+}
+
+func TestMatch_LowConfidenceAttachInMiddleBand(t *testing.T) {
+	// ~25 m offset (distance score ~0.5), name fully overlaps (1.0), no address.
+	// Score with redistribution: 0.5556*0.5 + 0.4444*1.0 = 0.7222 → low confidence.
+	repo := &fakeRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Pascal", Lat: 60.169675, Lng: 24.9384, Category: models.CategoryCafe},
+	}}
+	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	d, err := identity.Match(context.Background(), repo, r)
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if d.Kind != identity.KindLowConfidence {
+		t.Errorf("Kind = %v (confidence %v), want KindLowConfidence", d.Kind, d.Confidence)
+	}
+	if d.MatchedPlaceID != "p1" {
+		t.Errorf("MatchedPlaceID = %q, want %q", d.MatchedPlaceID, "p1")
+	}
+	if d.Confidence < 0.55 || d.Confidence >= 0.80 {
+		t.Errorf("Confidence = %v, want in [0.55, 0.80)", d.Confidence)
+	}
+}
+
+func TestMatch_BelowFloorReturnsNoMatch(t *testing.T) {
+	// ~40 m offset (distance ~0.2), name no overlap, no address.
+	// Score with redistribution: 0.5556*0.2 + 0.4444*0 = 0.111 → below floor.
+	repo := &fakeRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Roma", Lat: 60.17026, Lng: 24.9384, Category: models.CategoryCafe},
+	}}
+	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	d, err := identity.Match(context.Background(), repo, r)
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if d.Kind != identity.KindNoMatch {
+		t.Errorf("Kind = %v (confidence %v), want KindNoMatch", d.Kind, d.Confidence)
+	}
+	if d.MatchedPlaceID != "" {
+		t.Errorf("MatchedPlaceID = %q, want empty", d.MatchedPlaceID)
+	}
+}
+
+func TestMatch_PicksHighestScoringCandidate(t *testing.T) {
+	// Two candidates at the same point. One has a matching name, the other doesn't.
+	repo := &fakeRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Roma", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe},
+		{ID: "p2", Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe},
+	}}
+	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	d, err := identity.Match(context.Background(), repo, r)
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if d.MatchedPlaceID != "p2" {
+		t.Errorf("MatchedPlaceID = %q, want %q (highest-scoring)", d.MatchedPlaceID, "p2")
+	}
+}

--- a/internal/identity/matcher_test.go
+++ b/internal/identity/matcher_test.go
@@ -7,7 +7,10 @@ package identity_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/InWheelOrg/inwheel-api/internal/identity"
@@ -27,12 +30,39 @@ func (f *fakeRepo) FindCandidates(_ context.Context, _, _, _ float64, cats []mod
 	return f.candidates, f.err
 }
 
+type fixtureExpected struct {
+	Kind           string  `json:"Kind"`
+	MatchedPlaceID string  `json:"MatchedPlaceID"`
+	MinConfidence  float64 `json:"MinConfidence"`
+	MaxConfidence  float64 `json:"MaxConfidence"`
+}
+
+type fixture struct {
+	Name       string          `json:"name"`
+	Record     identity.Record `json:"record"`
+	Candidates []models.Place  `json:"candidates"`
+	Expected   fixtureExpected `json:"expected"`
+}
+
+func loadFixtures(t *testing.T) []fixture {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "match_fixtures.json"))
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+	var fixtures []fixture
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("unmarshal fixtures: %v", err)
+	}
+	return fixtures
+}
+
 func TestMatch_NoCandidatesReturnsNoMatch(t *testing.T) {
 	repo := &fakeRepo{candidates: nil}
 	r := identity.Record{
 		Name:     "Pascal",
-		Lat:      60.1699,
-		Lng:      24.9384,
+		Lat:      46.4628,
+		Lng:      6.8417,
 		Category: models.CategoryCafe,
 	}
 	d, err := identity.Match(context.Background(), repo, r)
@@ -54,8 +84,8 @@ func TestMatch_PassesCompatibleCategoriesToRepo(t *testing.T) {
 	repo := &fakeRepo{candidates: nil}
 	r := identity.Record{
 		Name:     "Pascal",
-		Lat:      60.1699,
-		Lng:      24.9384,
+		Lat:      46.4628,
+		Lng:      6.8417,
 		Category: models.CategoryCafe,
 	}
 	if _, err := identity.Match(context.Background(), repo, r); err != nil {
@@ -75,7 +105,7 @@ func TestMatch_PassesCompatibleCategoriesToRepo(t *testing.T) {
 func TestMatch_PropagatesRepoError(t *testing.T) {
 	wantErr := errors.New("db down")
 	repo := &fakeRepo{err: wantErr}
-	r := identity.Record{Lat: 60, Lng: 24, Category: models.CategoryCafe}
+	r := identity.Record{Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe}
 	_, err := identity.Match(context.Background(), repo, r)
 	if !errors.Is(err, wantErr) {
 		t.Errorf("err = %v, want %v", err, wantErr)
@@ -85,12 +115,12 @@ func TestMatch_PropagatesRepoError(t *testing.T) {
 func TestMatch_ConfidentAttachOnHighScore(t *testing.T) {
 	// Coincident point, identical name, matching address → score = 1.0
 	repo := &fakeRepo{candidates: []models.Place{
-		{ID: "p1", Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe,
-			Tags: models.PlaceTags{"addr:street": "Mannerheimintie", "addr:housenumber": "10"}},
+		{ID: "p1", Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+			Tags: models.PlaceTags{"addr:street": "Rue du Simplon", "addr:housenumber": "10"}},
 	}}
 	r := identity.Record{
-		Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe,
-		Street: "Mannerheimintie", HouseNumber: "10",
+		Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+		Street: "Rue du Simplon", HouseNumber: "10",
 	}
 	d, err := identity.Match(context.Background(), repo, r)
 	if err != nil {
@@ -111,9 +141,9 @@ func TestMatch_LowConfidenceAttachInMiddleBand(t *testing.T) {
 	// ~25 m offset (distance score ~0.5), name fully overlaps (1.0), no address.
 	// Score with redistribution: 0.5556*0.5 + 0.4444*1.0 = 0.7222 → low confidence.
 	repo := &fakeRepo{candidates: []models.Place{
-		{ID: "p1", Name: "Pascal", Lat: 60.169675, Lng: 24.9384, Category: models.CategoryCafe},
+		{ID: "p1", Name: "Pascal", Lat: 46.462575, Lng: 6.8417, Category: models.CategoryCafe},
 	}}
-	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	r := identity.Record{Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe}
 	d, err := identity.Match(context.Background(), repo, r)
 	if err != nil {
 		t.Fatalf("Match: %v", err)
@@ -133,9 +163,9 @@ func TestMatch_BelowFloorReturnsNoMatch(t *testing.T) {
 	// ~40 m offset (distance ~0.2), name no overlap, no address.
 	// Score with redistribution: 0.5556*0.2 + 0.4444*0 = 0.111 → below floor.
 	repo := &fakeRepo{candidates: []models.Place{
-		{ID: "p1", Name: "Roma", Lat: 60.17026, Lng: 24.9384, Category: models.CategoryCafe},
+		{ID: "p1", Name: "Roma", Lat: 46.46316, Lng: 6.8417, Category: models.CategoryCafe},
 	}}
-	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	r := identity.Record{Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe}
 	d, err := identity.Match(context.Background(), repo, r)
 	if err != nil {
 		t.Fatalf("Match: %v", err)
@@ -151,10 +181,10 @@ func TestMatch_BelowFloorReturnsNoMatch(t *testing.T) {
 func TestMatch_PicksHighestScoringCandidate(t *testing.T) {
 	// Two candidates at the same point. One has a matching name, the other doesn't.
 	repo := &fakeRepo{candidates: []models.Place{
-		{ID: "p1", Name: "Roma", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe},
-		{ID: "p2", Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe},
+		{ID: "p1", Name: "Roma", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe},
+		{ID: "p2", Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe},
 	}}
-	r := identity.Record{Name: "Pascal", Lat: 60.1699, Lng: 24.9384, Category: models.CategoryCafe}
+	r := identity.Record{Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe}
 	d, err := identity.Match(context.Background(), repo, r)
 	if err != nil {
 		t.Fatalf("Match: %v", err)
@@ -162,4 +192,41 @@ func TestMatch_PicksHighestScoringCandidate(t *testing.T) {
 	if d.MatchedPlaceID != "p2" {
 		t.Errorf("MatchedPlaceID = %q, want %q (highest-scoring)", d.MatchedPlaceID, "p2")
 	}
+}
+
+func TestMatch_Fixtures(t *testing.T) {
+	fixtures := loadFixtures(t)
+
+	var correct, total int
+	for _, f := range fixtures {
+		t.Run(f.Name, func(t *testing.T) {
+			repo := &fakeRepo{candidates: f.Candidates}
+			d, err := identity.Match(context.Background(), repo, f.Record)
+			if err != nil {
+				t.Fatalf("Match: %v", err)
+			}
+			pass := true
+			if d.Kind.String() != f.Expected.Kind {
+				t.Errorf("Kind = %q, want %q", d.Kind.String(), f.Expected.Kind)
+				pass = false
+			}
+			if f.Expected.MatchedPlaceID != "" && d.MatchedPlaceID != f.Expected.MatchedPlaceID {
+				t.Errorf("MatchedPlaceID = %q, want %q", d.MatchedPlaceID, f.Expected.MatchedPlaceID)
+				pass = false
+			}
+			if f.Expected.MinConfidence > 0 && d.Confidence < f.Expected.MinConfidence {
+				t.Errorf("Confidence = %v, want >= %v", d.Confidence, f.Expected.MinConfidence)
+				pass = false
+			}
+			if f.Expected.MaxConfidence > 0 && d.Confidence > f.Expected.MaxConfidence {
+				t.Errorf("Confidence = %v, want <= %v", d.Confidence, f.Expected.MaxConfidence)
+				pass = false
+			}
+			total++
+			if pass {
+				correct++
+			}
+		})
+	}
+	t.Logf("fixture accuracy: %d/%d (%.1f%%)", correct, total, 100*float64(correct)/float64(total))
 }

--- a/internal/identity/normalize.go
+++ b/internal/identity/normalize.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+// businessSuffixes are tokens dropped during Normalize.
+var businessSuffixes = map[string]struct{}{
+	"inc":  {},
+	"ltd":  {},
+	"llc":  {},
+	"co":   {},
+	"corp": {},
+	"gmbh": {},
+	"oy":   {},
+	"ab":   {},
+}
+
+// Normalize lowercases s, strips diacritics, replaces non-alphanumeric runes
+// with spaces, tokenizes on whitespace, and drops tokens in businessSuffixes.
+// Returns a slice of tokens (may be empty).
+func Normalize(s string) []string {
+	return nil
+}

--- a/internal/identity/normalize.go
+++ b/internal/identity/normalize.go
@@ -5,6 +5,15 @@
 
 package identity
 
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
 // businessSuffixes are tokens dropped during Normalize.
 var businessSuffixes = map[string]struct{}{
 	"inc":  {},
@@ -17,9 +26,47 @@ var businessSuffixes = map[string]struct{}{
 	"ab":   {},
 }
 
+// diacriticStripper NFKD-decomposes input and removes combining marks,
+// yielding ASCII-folded text for Latin-script languages.
+var diacriticStripper = transform.Chain(
+	norm.NFKD,
+	runes.Remove(runes.In(unicode.Mn)),
+	norm.NFC,
+)
+
 // Normalize lowercases s, strips diacritics, replaces non-alphanumeric runes
 // with spaces, tokenizes on whitespace, and drops tokens in businessSuffixes.
-// Returns a slice of tokens (may be empty).
+// Returns nil for empty or all-suffix input.
 func Normalize(s string) []string {
-	return nil
+	folded, _, err := transform.String(diacriticStripper, s)
+	if err != nil {
+		folded = s
+	}
+	folded = strings.ToLower(folded)
+
+	var b strings.Builder
+	b.Grow(len(folded))
+	for _, r := range folded {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune(' ')
+		}
+	}
+
+	fields := strings.Fields(b.String())
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for _, tok := range fields {
+		if _, drop := businessSuffixes[tok]; drop {
+			continue
+		}
+		out = append(out, tok)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/internal/identity/normalize.go
+++ b/internal/identity/normalize.go
@@ -26,19 +26,12 @@ var businessSuffixes = map[string]struct{}{
 	"ab":   {},
 }
 
-// diacriticStripper NFKD-decomposes input and removes combining marks,
-// yielding ASCII-folded text for Latin-script languages.
-var diacriticStripper = transform.Chain(
-	norm.NFKD,
-	runes.Remove(runes.In(unicode.Mn)),
-	norm.NFC,
-)
-
 // Normalize lowercases s, strips diacritics, replaces non-alphanumeric runes
 // with spaces, tokenizes on whitespace, and drops tokens in businessSuffixes.
 // Returns nil for empty or all-suffix input.
 func Normalize(s string) []string {
-	folded, _, err := transform.String(diacriticStripper, s)
+	t := transform.Chain(norm.NFKD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	folded, _, err := transform.String(t, s)
 	if err != nil {
 		folded = s
 	}

--- a/internal/identity/normalize_test.go
+++ b/internal/identity/normalize_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+)
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   \t\n  ", nil},
+		{"single word", "Pascal", []string{"pascal"}},
+		{"lowercase + tokenize", "Café Pascal", []string{"cafe", "pascal"}},
+		{"strip diacritics", "Açaí Bowl", []string{"acai", "bowl"}},
+		{"punctuation becomes whitespace", "PASCAL CAFE.", []string{"pascal", "cafe"}},
+		{"mixed separators", "Foo-Bar_Baz/Qux", []string{"foo", "bar", "baz", "qux"}},
+		{"drops business suffix inc", "Pascal Inc", []string{"pascal"}},
+		{"drops business suffix gmbh", "Beispiel GmbH", []string{"beispiel"}},
+		{"drops multiple suffixes", "Acme Co Ltd", []string{"acme"}},
+		{"preserves digits", "Cafe 22", []string{"cafe", "22"}},
+		{"all-suffix input returns empty", "Inc Ltd Co", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := identity.Normalize(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Normalize(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/identity/record.go
+++ b/internal/identity/record.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+import (
+	"encoding/json"
+
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// Record is one incoming non-OSM row being matched against the places table.
+// Ingestion source adapters (e.g. Wheelmap) construct a Record at the package
+// boundary from their upstream format.
+type Record struct {
+	// Source identifies the upstream system, e.g. "wheelmap".
+	Source string
+	// SourceID is the upstream's identifier for this row.
+	SourceID string
+	// Name is the human-readable name of the place.
+	Name string
+	// Lat is the latitude of the place.
+	Lat float64
+	// Lng is the longitude of the place.
+	Lng float64
+	// Category is the InWheel category the source mapped this row to.
+	Category models.Category
+	// Street is the normalized street name, empty if absent in the source.
+	Street string
+	// HouseNumber is the building number, empty if absent in the source.
+	HouseNumber string
+	// Payload is the raw upstream row, persisted to unmatched_external when
+	// no match is found so a retry sweep can re-evaluate it later.
+	Payload json.RawMessage
+}

--- a/internal/identity/score.go
+++ b/internal/identity/score.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+// Tuning constants. These shape every matching outcome.
+const (
+	// RadiusM is the candidate fetch radius in metres and the normaliser for
+	// distanceScore.
+	RadiusM = 50.0
+
+	// ConfidentThreshold is the minimum combined score to attach an external
+	// reference without a low-confidence flag.
+	ConfidentThreshold = 0.80
+
+	// LowConfidenceThreshold is the minimum combined score to attach at all.
+	LowConfidenceThreshold = 0.55
+
+	// WeightDistance is the weight applied to distanceScore in combinedScore.
+	WeightDistance = 0.5
+	// WeightName is the weight applied to nameScore in combinedScore.
+	WeightName = 0.4
+	// WeightAddress is the weight applied to addressScore in combinedScore.
+	WeightAddress = 0.1
+)
+
+// distanceScore returns 1.0 at coincident points and 0.0 at RadiusM, with a
+// linear falloff in between. Clamped to 0 for distances beyond RadiusM.
+func distanceScore(rLat, rLng, pLat, pLng float64) float64 {
+	return 0
+}
+
+// nameScore returns the token-set Jaccard similarity of the two normalized
+// names. Returns 0 when either side normalizes to an empty token set.
+func nameScore(rName, pName string) float64 {
+	return 0
+}
+
+// addressScore reports a 0/0.5/1 match score and a present flag. present is
+// false when either side has no street.
+func addressScore(rStreet, rHouse, pStreet, pHouse string) (score float64, present bool) {
+	return 0, false
+}
+
+// combinedScore folds the three component scores into a single value in [0, 1].
+// When addrPresent is false, WeightAddress is redistributed between distance
+// and name in proportion to their existing weights.
+func combinedScore(distance, name, address float64, addrPresent bool) float64 {
+	return 0
+}

--- a/internal/identity/score.go
+++ b/internal/identity/score.go
@@ -5,6 +5,11 @@
 
 package identity
 
+import (
+	"math"
+	"strings"
+)
+
 // Tuning constants. These shape every matching outcome.
 const (
 	// RadiusM is the candidate fetch radius in metres and the normaliser for
@@ -29,24 +34,93 @@ const (
 // distanceScore returns 1.0 at coincident points and 0.0 at RadiusM, with a
 // linear falloff in between. Clamped to 0 for distances beyond RadiusM.
 func distanceScore(rLat, rLng, pLat, pLng float64) float64 {
-	return 0
+	meters := haversineMeters(rLat, rLng, pLat, pLng)
+	if meters >= RadiusM {
+		return 0
+	}
+	return 1 - meters/RadiusM
+}
+
+// haversineMeters returns the great-circle distance between two WGS-84 points.
+func haversineMeters(lat1, lng1, lat2, lng2 float64) float64 {
+	const earthRadiusM = 6371008.8
+	toRad := func(d float64) float64 { return d * math.Pi / 180 }
+	dLat := toRad(lat2 - lat1)
+	dLng := toRad(lng2 - lng1)
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(toRad(lat1))*math.Cos(toRad(lat2))*
+			math.Sin(dLng/2)*math.Sin(dLng/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return earthRadiusM * c
 }
 
 // nameScore returns the token-set Jaccard similarity of the two normalized
 // names. Returns 0 when either side normalizes to an empty token set.
 func nameScore(rName, pName string) float64 {
-	return 0
+	r := tokenSet(Normalize(rName))
+	p := tokenSet(Normalize(pName))
+	if len(r) == 0 || len(p) == 0 {
+		return 0
+	}
+	var intersect int
+	for tok := range r {
+		if _, ok := p[tok]; ok {
+			intersect++
+		}
+	}
+	union := len(r) + len(p) - intersect
+	if union == 0 {
+		return 0
+	}
+	return float64(intersect) / float64(union)
+}
+
+func tokenSet(toks []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(toks))
+	for _, t := range toks {
+		set[t] = struct{}{}
+	}
+	return set
 }
 
 // addressScore reports a 0/0.5/1 match score and a present flag. present is
 // false when either side has no street.
 func addressScore(rStreet, rHouse, pStreet, pHouse string) (score float64, present bool) {
-	return 0, false
+	if rStreet == "" || pStreet == "" {
+		return 0, false
+	}
+	if !streetsMatch(rStreet, pStreet) {
+		return 0, true
+	}
+	if rHouse != "" && pHouse != "" && strings.EqualFold(rHouse, pHouse) {
+		return 1.0, true
+	}
+	return 0.5, true
+}
+
+func streetsMatch(a, b string) bool {
+	at := Normalize(a)
+	bt := Normalize(b)
+	if len(at) != len(bt) {
+		return false
+	}
+	for i := range at {
+		if at[i] != bt[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // combinedScore folds the three component scores into a single value in [0, 1].
 // When addrPresent is false, WeightAddress is redistributed between distance
 // and name in proportion to their existing weights.
 func combinedScore(distance, name, address float64, addrPresent bool) float64 {
-	return 0
+	if addrPresent {
+		return WeightDistance*distance + WeightName*name + WeightAddress*address
+	}
+	denom := WeightDistance + WeightName
+	wDist := WeightDistance + WeightAddress*WeightDistance/denom
+	wName := WeightName + WeightAddress*WeightName/denom
+	return wDist*distance + wName*name
 }

--- a/internal/identity/score_test.go
+++ b/internal/identity/score_test.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+import (
+	"math"
+	"testing"
+)
+
+const floatTolerance = 1e-6
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < floatTolerance
+}
+
+func TestDistanceScore(t *testing.T) {
+	// Helsinki city centre: 60.1699, 24.9384.
+	// At this latitude, ~0.000449 deg lat is ~50 m.
+	const lat = 60.1699
+	const lng = 24.9384
+
+	cases := []struct {
+		name         string
+		pLat         float64
+		pLng         float64
+		wantMinScore float64
+		wantMaxScore float64
+	}{
+		{"coincident", lat, lng, 0.999, 1.0},
+		{"25 m north", lat + 0.000225, lng, 0.45, 0.55},
+		{"50 m north (boundary)", lat + 0.000449, lng, 0.0, 0.05},
+		{"100 m north (beyond radius)", lat + 0.000898, lng, 0.0, 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := distanceScore(lat, lng, tc.pLat, tc.pLng)
+			if got < tc.wantMinScore || got > tc.wantMaxScore {
+				t.Errorf("distanceScore = %v, want in [%v, %v]", got, tc.wantMinScore, tc.wantMaxScore)
+			}
+		})
+	}
+}
+
+func TestNameScore(t *testing.T) {
+	cases := []struct {
+		name string
+		r    string
+		p    string
+		want float64
+	}{
+		{"identical", "Café Pascal", "Cafe Pascal", 1.0},
+		{"case + punctuation differ", "PASCAL CAFE.", "cafe pascal", 1.0},
+		{"one token overlap of two-each", "Cafe Pascal", "Cafe Roma", 1.0 / 3.0},
+		{"no overlap", "Pascal", "Roma", 0.0},
+		{"both empty after normalize", "", "", 0.0},
+		{"one empty after normalize", "Pascal", "", 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nameScore(tc.r, tc.p)
+			if !approxEqual(got, tc.want) {
+				t.Errorf("nameScore(%q, %q) = %v, want %v", tc.r, tc.p, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddressScore(t *testing.T) {
+	cases := []struct {
+		name        string
+		rStreet     string
+		rHouse      string
+		pStreet     string
+		pHouse      string
+		wantScore   float64
+		wantPresent bool
+	}{
+		{"full match", "Mannerheimintie", "10", "Mannerheimintie", "10", 1.0, true},
+		{"street match, both have house, house differs", "Mannerheimintie", "10", "Mannerheimintie", "12", 0.5, true},
+		{"street match, only one side has house", "Mannerheimintie", "10", "Mannerheimintie", "", 0.5, true},
+		{"street match, neither has house", "Mannerheimintie", "", "Mannerheimintie", "", 0.5, true},
+		{"street mismatch", "Mannerheimintie", "10", "Aleksanterinkatu", "10", 0.0, true},
+		{"record has no street", "", "10", "Mannerheimintie", "10", 0.0, false},
+		{"candidate has no street", "Mannerheimintie", "10", "", "10", 0.0, false},
+		{"both have no street", "", "", "", "", 0.0, false},
+		{"street match with diacritic difference", "Bulevárdi", "1", "Bulevardi", "1", 1.0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotScore, gotPresent := addressScore(tc.rStreet, tc.rHouse, tc.pStreet, tc.pHouse)
+			if gotPresent != tc.wantPresent {
+				t.Errorf("present = %v, want %v", gotPresent, tc.wantPresent)
+			}
+			if !approxEqual(gotScore, tc.wantScore) {
+				t.Errorf("score = %v, want %v", gotScore, tc.wantScore)
+			}
+		})
+	}
+}
+
+func TestCombinedScore(t *testing.T) {
+	cases := []struct {
+		name        string
+		distance    float64
+		nameVal     float64
+		address     float64
+		addrPresent bool
+		want        float64
+	}{
+		{"all max, address present", 1.0, 1.0, 1.0, true, 1.0},
+		{"all zero", 0.0, 0.0, 0.0, true, 0.0},
+		{"address present weighted sum", 0.8, 0.6, 0.5, true, 0.5*0.8 + 0.4*0.6 + 0.1*0.5},
+		{"address absent, all max distance and name", 1.0, 1.0, 0.0, false, 1.0},
+		{"address absent, max distance only", 1.0, 0.0, 0.0, false, 0.5 + 0.1*0.5/0.9},
+		{"address absent, max name only", 0.0, 1.0, 0.0, false, 0.4 + 0.1*0.4/0.9},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := combinedScore(tc.distance, tc.nameVal, tc.address, tc.addrPresent)
+			if !approxEqual(got, tc.want) {
+				t.Errorf("combinedScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/identity/score_test.go
+++ b/internal/identity/score_test.go
@@ -17,10 +17,9 @@ func approxEqual(a, b float64) bool {
 }
 
 func TestDistanceScore(t *testing.T) {
-	// Helsinki city centre: 60.1699, 24.9384.
 	// At this latitude, ~0.000449 deg lat is ~50 m.
-	const lat = 60.1699
-	const lng = 24.9384
+	const lat = 46.4628
+	const lng = 6.8417
 
 	cases := []struct {
 		name         string
@@ -78,13 +77,13 @@ func TestAddressScore(t *testing.T) {
 		wantScore   float64
 		wantPresent bool
 	}{
-		{"full match", "Mannerheimintie", "10", "Mannerheimintie", "10", 1.0, true},
-		{"street match, both have house, house differs", "Mannerheimintie", "10", "Mannerheimintie", "12", 0.5, true},
-		{"street match, only one side has house", "Mannerheimintie", "10", "Mannerheimintie", "", 0.5, true},
-		{"street match, neither has house", "Mannerheimintie", "", "Mannerheimintie", "", 0.5, true},
-		{"street mismatch", "Mannerheimintie", "10", "Aleksanterinkatu", "10", 0.0, true},
-		{"record has no street", "", "10", "Mannerheimintie", "10", 0.0, false},
-		{"candidate has no street", "Mannerheimintie", "10", "", "10", 0.0, false},
+		{"full match", "Rue du Simplon", "10", "Rue du Simplon", "10", 1.0, true},
+		{"street match, both have house, house differs", "Rue du Simplon", "10", "Rue du Simplon", "12", 0.5, true},
+		{"street match, only one side has house", "Rue du Simplon", "10", "Rue du Simplon", "", 0.5, true},
+		{"street match, neither has house", "Rue du Simplon", "", "Rue du Simplon", "", 0.5, true},
+		{"street mismatch", "Rue du Simplon", "10", "Grand-Rue", "10", 0.0, true},
+		{"record has no street", "", "10", "Rue du Simplon", "10", 0.0, false},
+		{"candidate has no street", "Rue du Simplon", "10", "", "10", 0.0, false},
 		{"both have no street", "", "", "", "", 0.0, false},
 		{"street match with diacritic difference", "Bulevárdi", "1", "Bulevardi", "1", 1.0, true},
 	}

--- a/internal/identity/testdata/match_fixtures.json
+++ b/internal/identity/testdata/match_fixtures.json
@@ -1,0 +1,67 @@
+[
+  {
+    "name": "confident: identical name, coincident point, matching address",
+    "record": {
+      "Name": "Café Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe",
+      "Street": "Rue du Simplon", "HouseNumber": "10"
+    },
+    "candidates": [
+      {"id": "p1", "name": "Café Pascal", "lat": 46.4628, "lng": 6.8417, "category": "cafe",
+       "tags": {"addr:street": "Rue du Simplon", "addr:housenumber": "10"}}
+    ],
+    "expected": {"Kind": "confident", "MatchedPlaceID": "p1", "MinConfidence": 0.95}
+  },
+  {
+    "name": "low confidence: 25 m away, name match, no address",
+    "record": {"Name": "Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [
+      {"id": "p1", "name": "Pascal", "lat": 46.462575, "lng": 6.8417, "category": "cafe"}
+    ],
+    "expected": {"Kind": "low_confidence", "MatchedPlaceID": "p1", "MinConfidence": 0.55, "MaxConfidence": 0.80}
+  },
+  {
+    "name": "no match: no candidates returned",
+    "record": {"Name": "Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [],
+    "expected": {"Kind": "no_match"}
+  },
+  {
+    "name": "no match: single candidate scores below floor",
+    "record": {"Name": "Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [
+      {"id": "p1", "name": "Roma", "lat": 46.46316, "lng": 6.8417, "category": "cafe"}
+    ],
+    "expected": {"Kind": "no_match"}
+  },
+  {
+    "name": "argmax: highest-scoring candidate wins",
+    "record": {"Name": "Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [
+      {"id": "p1", "name": "Roma", "lat": 46.4628, "lng": 6.8417, "category": "cafe"},
+      {"id": "p2", "name": "Pascal", "lat": 46.4628, "lng": 6.8417, "category": "cafe"}
+    ],
+    "expected": {"Kind": "confident", "MatchedPlaceID": "p2", "MinConfidence": 0.55}
+  },
+  {
+    "name": "address absent: still confident on strong name + distance",
+    "record": {"Name": "Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [
+      {"id": "p1", "name": "Pascal", "lat": 46.4628, "lng": 6.8417, "category": "cafe"}
+    ],
+    "expected": {"Kind": "confident", "MatchedPlaceID": "p1", "MinConfidence": 0.95}
+  },
+  {
+    "name": "diacritic normalization: Café matches Cafe",
+    "record": {"Name": "Café Pascal", "Lat": 46.4628, "Lng": 6.8417, "Category": "cafe"},
+    "candidates": [
+      {"id": "p1", "name": "Cafe Pascal", "lat": 46.4628, "lng": 6.8417, "category": "cafe"}
+    ],
+    "expected": {"Kind": "confident", "MatchedPlaceID": "p1", "MinConfidence": 0.95}
+  },
+  {
+    "name": "category incompatible: fake repo returns empty",
+    "record": {"Name": "Pascal Pharmacy", "Lat": 46.4628, "Lng": 6.8417, "Category": "healthcare"},
+    "candidates": [],
+    "expected": {"Kind": "no_match"}
+  }
+]

--- a/internal/place/repository.go
+++ b/internal/place/repository.go
@@ -58,3 +58,40 @@ func (r *Repository) UpsertBatch(ctx context.Context, places []models.Place) err
 	}
 	return nil
 }
+
+// FindCandidates returns active places within radiusM metres of (lat, lng)
+// whose category is in categories, ordered by ascending distance, capped at 32.
+// Satisfies identity.CandidateRepo.
+func (r *Repository) FindCandidates(
+	ctx context.Context,
+	lat, lng, radiusM float64,
+	categories []models.Category,
+) ([]models.Place, error) {
+	if len(categories) == 0 {
+		return nil, nil
+	}
+	point := fmt.Sprintf("SRID=4326;POINT(%f %f)", lng, lat)
+	var out []models.Place
+	tx := r.db.WithContext(ctx).
+		Where("status = ?", models.PlaceStatusActive).
+		Where("category IN ?", categories).
+		Where("ST_DWithin(geom, ?::geography, ?)", point, radiusM).
+		Order(fmt.Sprintf("ST_Distance(geom, '%s'::geography) ASC", point)).
+		Limit(32).
+		Find(&out)
+	if tx.Error != nil {
+		return nil, fmt.Errorf("find candidates: %w", tx.Error)
+	}
+	return out, nil
+}
+
+// Compile-time assertion that *Repository satisfies identity.CandidateRepo.
+// The assertion lives here so a signature drift in either side fails the build
+// at the boundary, not at the first caller.
+var _ interface {
+	FindCandidates(
+		ctx context.Context,
+		lat, lng, radiusM float64,
+		categories []models.Category,
+	) ([]models.Place, error)
+} = (*Repository)(nil)

--- a/internal/place/repository.go
+++ b/internal/place/repository.go
@@ -76,7 +76,7 @@ func (r *Repository) FindCandidates(
 		Where("status = ?", models.PlaceStatusActive).
 		Where("category IN ?", categories).
 		Where("ST_DWithin(geom, ?::geography, ?)", point, radiusM).
-		Order(fmt.Sprintf("ST_Distance(geom, '%s'::geography) ASC", point)).
+		Order(gorm.Expr("ST_Distance(geom, ?::geography) ASC", point)).
 		Limit(32).
 		Find(&out)
 	if tx.Error != nil {

--- a/internal/place/repository.go
+++ b/internal/place/repository.go
@@ -70,13 +70,17 @@ func (r *Repository) FindCandidates(
 	if len(categories) == 0 {
 		return nil, nil
 	}
-	point := fmt.Sprintf("SRID=4326;POINT(%f %f)", lng, lat)
 	var out []models.Place
 	tx := r.db.WithContext(ctx).
 		Where("status = ?", models.PlaceStatusActive).
 		Where("category IN ?", categories).
-		Where("ST_DWithin(geom, ?::geography, ?)", point, radiusM).
-		Order(gorm.Expr("ST_Distance(geom, ?::geography) ASC", point)).
+		Where("ST_DWithin(geography(ST_Point(lng, lat)), geography(ST_Point(?, ?)), ?)", lng, lat, radiusM).
+		Clauses(clause.OrderBy{
+			Expression: clause.Expr{
+				SQL:  "ST_Distance(geography(ST_Point(lng, lat)), geography(ST_Point(?, ?))) ASC",
+				Vars: []interface{}{lng, lat},
+			},
+		}).
 		Limit(32).
 		Find(&out)
 	if tx.Error != nil {

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -107,6 +107,105 @@ func TestUpsertBatch_EmptySliceIsNoOp(t *testing.T) {
 	}
 }
 
+func TestFindCandidates_EmptyCategoriesReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+	got, err := repo.FindCandidates(ctx, 46.4628, 6.8417, 50, nil)
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestFindCandidates_RadiusStatusCategoryFilters(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	// At this latitude, ~0.000225 deg lat ≈ 25 m; ~0.000898 deg lat ≈ 100 m.
+	const cLat, cLng = 46.4628, 6.8417
+
+	seed := []models.Place{
+		// near + matching category + active → returned
+		{OSMID: 1, OSMType: models.OSMNode, Name: "Near Cafe", Lat: cLat + 0.0001, Lng: cLng, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+		// far (~100 m) + matching category + active → excluded by radius
+		{OSMID: 2, OSMType: models.OSMNode, Name: "Far Cafe", Lat: cLat + 0.000898, Lng: cLng, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+		// near + wrong category + active → excluded by category filter
+		{OSMID: 3, OSMType: models.OSMNode, Name: "Near Pharmacy", Lat: cLat, Lng: cLng + 0.0001, Category: models.CategoryHealthcare, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+		// near + matching category + closed → excluded by status filter
+		{OSMID: 4, OSMType: models.OSMNode, Name: "Closed Cafe", Lat: cLat - 0.0001, Lng: cLng, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusClosed},
+	}
+	if err := repo.UpsertBatch(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := repo.FindCandidates(ctx, cLat, cLng, 50, []models.Category{models.CategoryCafe})
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d candidates, want 1: %v", len(got), names(got))
+	}
+	if got[0].Name != "Near Cafe" {
+		t.Errorf("got %q, want %q", got[0].Name, "Near Cafe")
+	}
+}
+
+func TestFindCandidates_OrdersByDistance(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	const cLat, cLng = 46.4628, 6.8417
+
+	seed := []models.Place{
+		// ~40 m north
+		{OSMID: 1, OSMType: models.OSMNode, Name: "Far", Lat: cLat + 0.00036, Lng: cLng, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+		// ~10 m north (closer)
+		{OSMID: 2, OSMType: models.OSMNode, Name: "Near", Lat: cLat + 0.00009, Lng: cLng, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+	}
+	if err := repo.UpsertBatch(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := repo.FindCandidates(ctx, cLat, cLng, 50, []models.Category{models.CategoryCafe})
+	if err != nil {
+		t.Fatalf("FindCandidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d candidates, want 2", len(got))
+	}
+	if got[0].Name != "Near" || got[1].Name != "Far" {
+		t.Errorf("order = [%q, %q], want [\"Near\", \"Far\"]", got[0].Name, got[1].Name)
+	}
+}
+
+func names(ps []models.Place) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Name
+	}
+	return out
+}
+
 func TestUnmatchedExternal_TableRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	db, cleanup, err := testhelpers.StartPostgres(ctx)


### PR DESCRIPTION
## Summary

- New `internal/identity` package: pure scoring + matching logic, fixture-driven tests.
- `place.Repository.FindCandidates` for spatial + category lookup, satisfying `identity.CandidateRepo`.
- No source calls `Match` yet — wiring is the next sub-issue.

## Algorithm

1. Candidate fetch: active places within 50m whose category is compatible (allowlist).
2. Score each: `0.5*distance + 0.4*name + 0.1*address`. Distance linear falloff to 50m. Name is token-set Jaccard over normalized tokens. Address is 1.0/0.5/0 with weight redistributed proportionally when absent.
3. Decide: ≥0.80 confident, ≥0.55 low-confidence, else no match.

## Test plan

- [x] \`go test ./internal/identity/...\`
- [x] \`go test ./...\` — no regressions
- [x] \`go vet ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #70