### PR TITLE
Add identity.Resolver to route Match decisions

### DIFF
--- a/internal/identity/resolve.go
+++ b/internal/identity/resolve.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// AttachRepo writes an external reference onto an existing place.
+type AttachRepo interface {
+	AttachExternalRef(ctx context.Context, placeID, source string, ref models.ExternalRef) error
+}
+
+// EnqueueRepo persists a record to the retry queue.
+type EnqueueRepo interface {
+	Enqueue(ctx context.Context, u models.UnmatchedExternal) error
+}
+
+// Resolver runs Match on an incoming Record and applies the resulting Decision.
+// Candidates, Places, and Unmatched are typically backed by the same place
+// repository; the three interfaces stay separate so each call site declares
+// only what it needs.
+type Resolver struct {
+	Candidates CandidateRepo
+	Places     AttachRepo
+	Unmatched  EnqueueRepo
+	// Now returns the current time. Nil defaults to time.Now.
+	Now func() time.Time
+}
+
+// Resolve runs Match on rec and applies the resulting Decision: confident or
+// low-confidence matches attach an external ref to the matched place; no-match
+// enqueues rec for the retry sweep. The Decision is returned alongside any
+// error so the caller can update counters without re-matching.
+func (r *Resolver) Resolve(ctx context.Context, rec Record) (Decision, error) {
+	now := r.Now
+	if now == nil {
+		now = time.Now
+	}
+	d, err := Match(ctx, r.Candidates, rec)
+	if err != nil {
+		return Decision{}, fmt.Errorf("match: %w", err)
+	}
+	switch d.Kind {
+	case KindConfident, KindLowConfidence:
+		ref := models.ExternalRef{
+			ID:         rec.SourceID,
+			Confidence: d.Confidence,
+			MatchedAt:  now(),
+		}
+		if err := r.Places.AttachExternalRef(ctx, d.MatchedPlaceID, rec.Source, ref); err != nil {
+			return Decision{}, fmt.Errorf("attach external ref: %w", err)
+		}
+	case KindNoMatch:
+		u := models.UnmatchedExternal{
+			Source:        rec.Source,
+			SourceID:      rec.SourceID,
+			Lat:           rec.Lat,
+			Lng:           rec.Lng,
+			Payload:       rec.Payload,
+			LastAttempted: now(),
+		}
+		if err := r.Unmatched.Enqueue(ctx, u); err != nil {
+			return Decision{}, fmt.Errorf("enqueue unmatched: %w", err)
+		}
+	}
+	return d, nil
+}

--- a/internal/identity/resolve.go
+++ b/internal/identity/resolve.go
@@ -7,6 +7,7 @@ package identity
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,21 +25,16 @@ type EnqueueRepo interface {
 }
 
 // Resolver runs Match on an incoming Record and applies the resulting Decision.
-// Candidates, Places, and Unmatched are typically backed by the same place
-// repository; the three interfaces stay separate so each call site declares
-// only what it needs.
 type Resolver struct {
 	Candidates CandidateRepo
 	Places     AttachRepo
 	Unmatched  EnqueueRepo
-	// Now returns the current time. Nil defaults to time.Now.
-	Now func() time.Time
+	Now        func() time.Time
 }
 
 // Resolve runs Match on rec and applies the resulting Decision: confident or
 // low-confidence matches attach an external ref to the matched place; no-match
-// enqueues rec for the retry sweep. The Decision is returned alongside any
-// error so the caller can update counters without re-matching.
+// enqueues rec for the retry sweep.
 func (r *Resolver) Resolve(ctx context.Context, rec Record) (Decision, error) {
 	now := r.Now
 	if now == nil {
@@ -59,17 +55,24 @@ func (r *Resolver) Resolve(ctx context.Context, rec Record) (Decision, error) {
 			return Decision{}, fmt.Errorf("attach external ref: %w", err)
 		}
 	case KindNoMatch:
+		payload := rec.Payload
+		if payload == nil {
+			payload = json.RawMessage("{}")
+		}
 		u := models.UnmatchedExternal{
 			Source:        rec.Source,
 			SourceID:      rec.SourceID,
 			Lat:           rec.Lat,
 			Lng:           rec.Lng,
-			Payload:       rec.Payload,
+			Payload:       payload,
 			LastAttempted: now(),
+			Attempts:      1,
 		}
 		if err := r.Unmatched.Enqueue(ctx, u); err != nil {
 			return Decision{}, fmt.Errorf("enqueue unmatched: %w", err)
 		}
+	default:
+		return Decision{}, fmt.Errorf("unhandled decision kind: %v", d.Kind)
 	}
 	return d, nil
 }

--- a/internal/identity/resolve_test.go
+++ b/internal/identity/resolve_test.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package identity_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+type fakeAttachRepo struct {
+	calls []attachCall
+	err   error
+}
+
+type attachCall struct {
+	placeID string
+	source  string
+	ref     models.ExternalRef
+}
+
+func (f *fakeAttachRepo) AttachExternalRef(_ context.Context, placeID, source string, ref models.ExternalRef) error {
+	f.calls = append(f.calls, attachCall{placeID, source, ref})
+	return f.err
+}
+
+type fakeEnqueueRepo struct {
+	calls []models.UnmatchedExternal
+	err   error
+}
+
+func (f *fakeEnqueueRepo) Enqueue(_ context.Context, u models.UnmatchedExternal) error {
+	f.calls = append(f.calls, u)
+	return f.err
+}
+
+type candidatesRepo struct {
+	candidates []models.Place
+	err        error
+}
+
+func (c *candidatesRepo) FindCandidates(_ context.Context, _, _, _ float64, _ []models.Category) ([]models.Place, error) {
+	return c.candidates, c.err
+}
+
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func TestResolve_ConfidentAttachesExternalRef(t *testing.T) {
+	clock := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	attach := &fakeAttachRepo{}
+	enqueue := &fakeEnqueueRepo{}
+	cands := &candidatesRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+			Tags: models.PlaceTags{"addr:street": "Rue du Simplon", "addr:housenumber": "10"}},
+	}}
+	r := &identity.Resolver{
+		Candidates: cands, Places: attach, Unmatched: enqueue, Now: fixedClock(clock),
+	}
+	rec := identity.Record{
+		Source: "wheelmap", SourceID: "abc",
+		Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+		Street: "Rue du Simplon", HouseNumber: "10",
+	}
+	d, err := r.Resolve(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.Kind != identity.KindConfident {
+		t.Fatalf("Decision.Kind = %v, want KindConfident", d.Kind)
+	}
+	if len(attach.calls) != 1 {
+		t.Fatalf("AttachExternalRef calls = %d, want 1", len(attach.calls))
+	}
+	got := attach.calls[0]
+	if got.placeID != "p1" || got.source != "wheelmap" {
+		t.Errorf("attach call = %+v, want placeID=p1 source=wheelmap", got)
+	}
+	if got.ref.ID != "abc" {
+		t.Errorf("ref.ID = %q, want %q", got.ref.ID, "abc")
+	}
+	if got.ref.Confidence < 0.99 {
+		t.Errorf("ref.Confidence = %v, want >= 0.99", got.ref.Confidence)
+	}
+	if !got.ref.MatchedAt.Equal(clock) {
+		t.Errorf("ref.MatchedAt = %v, want %v", got.ref.MatchedAt, clock)
+	}
+	if len(enqueue.calls) != 0 {
+		t.Errorf("Enqueue calls = %d, want 0", len(enqueue.calls))
+	}
+}
+
+func TestResolve_LowConfidenceAttachesWithLowScore(t *testing.T) {
+	clock := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	attach := &fakeAttachRepo{}
+	enqueue := &fakeEnqueueRepo{}
+	cands := &candidatesRepo{candidates: []models.Place{
+		{ID: "p2", Name: "Pascal", Lat: 46.462575, Lng: 6.8417, Category: models.CategoryCafe},
+	}}
+	r := &identity.Resolver{
+		Candidates: cands, Places: attach, Unmatched: enqueue, Now: fixedClock(clock),
+	}
+	rec := identity.Record{
+		Source: "wheelmap", SourceID: "xyz",
+		Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+	}
+	d, err := r.Resolve(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.Kind != identity.KindLowConfidence {
+		t.Fatalf("Decision.Kind = %v (confidence %v), want KindLowConfidence", d.Kind, d.Confidence)
+	}
+	if len(attach.calls) != 1 {
+		t.Fatalf("AttachExternalRef calls = %d, want 1", len(attach.calls))
+	}
+	got := attach.calls[0]
+	if got.placeID != "p2" {
+		t.Errorf("attach placeID = %q, want p2", got.placeID)
+	}
+	if got.ref.Confidence < 0.55 || got.ref.Confidence >= 0.80 {
+		t.Errorf("ref.Confidence = %v, want in [0.55, 0.80)", got.ref.Confidence)
+	}
+	if !got.ref.MatchedAt.Equal(clock) {
+		t.Errorf("ref.MatchedAt = %v, want %v", got.ref.MatchedAt, clock)
+	}
+	if len(enqueue.calls) != 0 {
+		t.Errorf("Enqueue calls = %d, want 0", len(enqueue.calls))
+	}
+}
+
+func TestResolve_NoMatchEnqueues(t *testing.T) {
+	clock := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	attach := &fakeAttachRepo{}
+	enqueue := &fakeEnqueueRepo{}
+	cands := &candidatesRepo{candidates: nil}
+	r := &identity.Resolver{
+		Candidates: cands, Places: attach, Unmatched: enqueue, Now: fixedClock(clock),
+	}
+	payload := json.RawMessage(`{"raw":"data"}`)
+	rec := identity.Record{
+		Source: "wheelmap", SourceID: "ghost",
+		Name: "Nowhere", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+		Payload: payload,
+	}
+	d, err := r.Resolve(context.Background(), rec)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.Kind != identity.KindNoMatch {
+		t.Fatalf("Decision.Kind = %v, want KindNoMatch", d.Kind)
+	}
+	if len(attach.calls) != 0 {
+		t.Errorf("AttachExternalRef calls = %d, want 0", len(attach.calls))
+	}
+	if len(enqueue.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1", len(enqueue.calls))
+	}
+	got := enqueue.calls[0]
+	if got.Source != "wheelmap" || got.SourceID != "ghost" {
+		t.Errorf("enqueued source/id = %q/%q, want wheelmap/ghost", got.Source, got.SourceID)
+	}
+	if got.Lat != 46.4628 || got.Lng != 6.8417 {
+		t.Errorf("enqueued lat/lng = %v/%v, want 46.4628/6.8417", got.Lat, got.Lng)
+	}
+	if string(got.Payload) != string(payload) {
+		t.Errorf("enqueued payload = %s, want %s", got.Payload, payload)
+	}
+	if !got.LastAttempted.Equal(clock) {
+		t.Errorf("enqueued LastAttempted = %v, want %v", got.LastAttempted, clock)
+	}
+}
+
+func TestResolve_NilClockDefaultsToTimeNow(t *testing.T) {
+	attach := &fakeAttachRepo{}
+	enqueue := &fakeEnqueueRepo{}
+	cands := &candidatesRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe},
+	}}
+	r := &identity.Resolver{
+		Candidates: cands, Places: attach, Unmatched: enqueue, Now: nil,
+	}
+	before := time.Now()
+	_, err := r.Resolve(context.Background(), identity.Record{
+		Source: "wheelmap", SourceID: "x",
+		Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+	})
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(attach.calls) != 1 {
+		t.Fatalf("AttachExternalRef calls = %d, want 1", len(attach.calls))
+	}
+	got := attach.calls[0].ref.MatchedAt
+	if got.Before(before) || got.After(after) {
+		t.Errorf("MatchedAt = %v, want in [%v, %v]", got, before, after)
+	}
+}
+
+func TestResolve_PropagatesMatchError(t *testing.T) {
+	wantErr := errors.New("db down")
+	r := &identity.Resolver{
+		Candidates: &candidatesRepo{err: wantErr},
+		Places:     &fakeAttachRepo{},
+		Unmatched:  &fakeEnqueueRepo{},
+		Now:        time.Now,
+	}
+	d, err := r.Resolve(context.Background(), identity.Record{
+		Name: "x", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+	if d != (identity.Decision{}) {
+		t.Errorf("Decision = %+v, want zero value", d)
+	}
+}
+
+func TestResolve_PropagatesAttachError(t *testing.T) {
+	wantErr := errors.New("attach failed")
+	cands := &candidatesRepo{candidates: []models.Place{
+		{ID: "p1", Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe},
+	}}
+	r := &identity.Resolver{
+		Candidates: cands,
+		Places:     &fakeAttachRepo{err: wantErr},
+		Unmatched:  &fakeEnqueueRepo{},
+		Now:        time.Now,
+	}
+	_, err := r.Resolve(context.Background(), identity.Record{
+		Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+}
+
+func TestResolve_PropagatesEnqueueError(t *testing.T) {
+	wantErr := errors.New("enqueue failed")
+	r := &identity.Resolver{
+		Candidates: &candidatesRepo{candidates: nil},
+		Places:     &fakeAttachRepo{},
+		Unmatched:  &fakeEnqueueRepo{err: wantErr},
+		Now:        time.Now,
+	}
+	_, err := r.Resolve(context.Background(), identity.Record{
+		Name: "x", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+}

--- a/internal/identity/resolve_test.go
+++ b/internal/identity/resolve_test.go
@@ -176,6 +176,33 @@ func TestResolve_NoMatchEnqueues(t *testing.T) {
 	if !got.LastAttempted.Equal(clock) {
 		t.Errorf("enqueued LastAttempted = %v, want %v", got.LastAttempted, clock)
 	}
+	if got.Attempts != 1 {
+		t.Errorf("enqueued Attempts = %d, want 1", got.Attempts)
+	}
+}
+
+func TestResolve_NoMatchNilPayloadDefaultsToEmptyObject(t *testing.T) {
+	enqueue := &fakeEnqueueRepo{}
+	r := &identity.Resolver{
+		Candidates: &candidatesRepo{candidates: nil},
+		Places:     &fakeAttachRepo{},
+		Unmatched:  enqueue,
+		Now:        fixedClock(time.Now()),
+	}
+	_, err := r.Resolve(context.Background(), identity.Record{
+		Source: "wheelmap", SourceID: "no-payload",
+		Name: "Nowhere", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+		Payload: nil,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(enqueue.calls) != 1 {
+		t.Fatalf("Enqueue calls = %d, want 1", len(enqueue.calls))
+	}
+	if string(enqueue.calls[0].Payload) != "{}" {
+		t.Errorf("enqueued Payload = %s, want {}", enqueue.calls[0].Payload)
+	}
 }
 
 func TestResolve_NilClockDefaultsToTimeNow(t *testing.T) {

--- a/pkg/models/place.go
+++ b/pkg/models/place.go
@@ -201,3 +201,20 @@ func (e ExternalIDs) Value() (driver.Value, error) {
 	}
 	return json.Marshal(e)
 }
+
+// UnmatchedExternal is one queued non-OSM record awaiting a future match.
+// Rows live in the unmatched_external table and are drained by the retry
+// sweep after each OSM ingest of the surrounding region.
+type UnmatchedExternal struct {
+	ID            int64           `gorm:"primaryKey"`
+	Source        string          `gorm:"not null"`
+	SourceID      string          `gorm:"column:source_id;not null"`
+	Lat           float64         `gorm:"not null"`
+	Lng           float64         `gorm:"not null"`
+	Payload       json.RawMessage `gorm:"type:jsonb;not null"`
+	LastAttempted time.Time       `gorm:"column:last_attempted;not null"`
+	Attempts      int             `gorm:"not null;default:1"`
+}
+
+// TableName tells GORM the explicit table name (no pluralisation of "unmatched").
+func (UnmatchedExternal) TableName() string { return "unmatched_external" }


### PR DESCRIPTION
## Summary
- Adds `identity.Resolver` — runs `Match` on a `Record` and applies the resulting `Decision` (attach on confident/low-confidence, enqueue on no-match).
- Defines narrow `AttachRepo` and `EnqueueRepo` interfaces in the identity package; concrete implementations ship in follow-up PRs.
- Adds `models.UnmatchedExternal` for the existing `unmatched_external` table (table was introduced in #69 but no Go type mapped to it).
- Clock is injectable so tests assert exact timestamps; nil-defaults to `time.Now`.
- Resolver is dead code at this point — nothing calls it yet.

## Test plan
- [x] Unit tests cover all three Decision branches plus error propagation paths.
- [x] Timestamps asserted exactly via injected fixed clock.
- [x] `go test -race ./internal/identity/` passes.
- [x] `go vet ./...` and `gofmt -l` clean.

Closes #77