### PR TITLE
Add place.Repository.AttachExternalRef

### DIFF
--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/internal/place/repository.go
+++ b/internal/place/repository.go
@@ -8,11 +8,13 @@ package place
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
 )
 
@@ -89,6 +91,39 @@ func (r *Repository) FindCandidates(
 	return out, nil
 }
 
+// AttachExternalRef upserts ref into the place's external_ids map under the
+// given source key, atomically via jsonb_set. Returns an error if no row has
+// the given id.
+func (r *Repository) AttachExternalRef(
+	ctx context.Context,
+	placeID, source string,
+	ref models.ExternalRef,
+) error {
+	refJSON, err := json.Marshal(ref)
+	if err != nil {
+		return fmt.Errorf("marshal external ref: %w", err)
+	}
+	tx := r.db.WithContext(ctx).Exec(
+		`UPDATE places
+         SET external_ids = jsonb_set(
+                COALESCE(external_ids, '{}'::jsonb),
+                ARRAY[?],
+                ?::jsonb,
+                true
+            ),
+            updated_at = NOW()
+         WHERE id = ?`,
+		source, string(refJSON), placeID,
+	)
+	if tx.Error != nil {
+		return fmt.Errorf("attach external ref: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("attach external ref: place %q not found", placeID)
+	}
+	return nil
+}
+
 // Compile-time assertion that *Repository satisfies identity.CandidateRepo.
 // The assertion lives here so a signature drift in either side fails the build
 // at the boundary, not at the first caller.
@@ -99,3 +134,6 @@ var _ interface {
 		categories []models.Category,
 	) ([]models.Place, error)
 } = (*Repository)(nil)
+
+// Compile-time assertion that *Repository satisfies identity.AttachRepo.
+var _ identity.AttachRepo = (*Repository)(nil)

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -10,6 +10,7 @@ package place_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/InWheelOrg/inwheel-api/internal/place"
 	"github.com/InWheelOrg/inwheel-api/internal/testhelpers"
@@ -319,6 +320,168 @@ func TestUnmatchedExternal_ColumnDefaults(t *testing.T) {
 	}
 	if lastAttempted == nil {
 		t.Error("last_attempted is NULL, want a timestamp from DEFAULT NOW()")
+	}
+}
+
+func TestAttachExternalRef_EmptyMap(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	seed := []models.Place{
+		{OSMID: 10, OSMType: models.OSMNode, Name: "Vevey Cafe", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive},
+	}
+	if err := repo.UpsertBatch(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var seeded models.Place
+	if err := db.Where("osm_id = ?", 10).First(&seeded).Error; err != nil {
+		t.Fatalf("fetch seeded place: %v", err)
+	}
+
+	matchedAt := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	ref := models.ExternalRef{ID: "wm/10", Confidence: 0.9, MatchedAt: matchedAt}
+	if err := repo.AttachExternalRef(ctx, seeded.ID, "wheelmap", ref); err != nil {
+		t.Fatalf("AttachExternalRef: %v", err)
+	}
+
+	var got models.Place
+	if err := db.Where("osm_id = ?", 10).First(&got).Error; err != nil {
+		t.Fatalf("reload place: %v", err)
+	}
+	wm, ok := got.ExternalIDs["wheelmap"]
+	if !ok {
+		t.Fatal("external_ids[wheelmap] missing")
+	}
+	if wm.ID != "wm/10" {
+		t.Errorf("ID = %q, want %q", wm.ID, "wm/10")
+	}
+	if wm.Confidence != 0.9 {
+		t.Errorf("Confidence = %v, want 0.9", wm.Confidence)
+	}
+	if wm.MatchedAt.UnixMicro() != matchedAt.Truncate(time.Microsecond).UnixMicro() {
+		t.Errorf("MatchedAt = %v, want %v", wm.MatchedAt, matchedAt)
+	}
+}
+
+func TestAttachExternalRef_ExistingDifferentKey(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	seed := []models.Place{
+		{OSMID: 11, OSMType: models.OSMNode, Name: "Vevey Pharmacy", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryHealthcare, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive, ExternalIDs: models.ExternalIDs{"osm": models.ExternalRef{ID: "node/123", Confidence: 1.0}}},
+	}
+	if err := repo.UpsertBatch(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var seeded models.Place
+	if err := db.Where("osm_id = ?", 11).First(&seeded).Error; err != nil {
+		t.Fatalf("fetch seeded place: %v", err)
+	}
+
+	matchedAt := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	ref := models.ExternalRef{ID: "wm/11", Confidence: 0.85, MatchedAt: matchedAt}
+	if err := repo.AttachExternalRef(ctx, seeded.ID, "wheelmap", ref); err != nil {
+		t.Fatalf("AttachExternalRef: %v", err)
+	}
+
+	var got models.Place
+	if err := db.Where("osm_id = ?", 11).First(&got).Error; err != nil {
+		t.Fatalf("reload place: %v", err)
+	}
+	if got.ExternalIDs["osm"].ID != "node/123" {
+		t.Errorf("osm entry changed: ID = %q, want %q", got.ExternalIDs["osm"].ID, "node/123")
+	}
+	if got.ExternalIDs["osm"].Confidence != 1.0 {
+		t.Errorf("osm Confidence = %v, want 1.0", got.ExternalIDs["osm"].Confidence)
+	}
+	wm, ok := got.ExternalIDs["wheelmap"]
+	if !ok {
+		t.Fatal("external_ids[wheelmap] missing")
+	}
+	if wm.ID != "wm/11" {
+		t.Errorf("wheelmap ID = %q, want %q", wm.ID, "wm/11")
+	}
+	if wm.Confidence != 0.85 {
+		t.Errorf("wheelmap Confidence = %v, want 0.85", wm.Confidence)
+	}
+}
+
+func TestAttachExternalRef_ExistingSameKey(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	oldTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	seed := []models.Place{
+		{OSMID: 12, OSMType: models.OSMNode, Name: "Vevey Restaurant", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryRestaurant, Rank: models.RankEstablishment, Source: "osm", Status: models.PlaceStatusActive, ExternalIDs: models.ExternalIDs{"wheelmap": models.ExternalRef{ID: "old", Confidence: 0.6, MatchedAt: oldTime}}},
+	}
+	if err := repo.UpsertBatch(ctx, seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var seeded models.Place
+	if err := db.Where("osm_id = ?", 12).First(&seeded).Error; err != nil {
+		t.Fatalf("fetch seeded place: %v", err)
+	}
+
+	newTime := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	newRef := models.ExternalRef{ID: "new", Confidence: 0.95, MatchedAt: newTime}
+	if err := repo.AttachExternalRef(ctx, seeded.ID, "wheelmap", newRef); err != nil {
+		t.Fatalf("AttachExternalRef: %v", err)
+	}
+
+	var got models.Place
+	if err := db.Where("osm_id = ?", 12).First(&got).Error; err != nil {
+		t.Fatalf("reload place: %v", err)
+	}
+	wm, ok := got.ExternalIDs["wheelmap"]
+	if !ok {
+		t.Fatal("external_ids[wheelmap] missing after overwrite")
+	}
+	if wm.ID != "new" {
+		t.Errorf("ID = %q, want %q", wm.ID, "new")
+	}
+	if wm.Confidence != 0.95 {
+		t.Errorf("Confidence = %v, want 0.95", wm.Confidence)
+	}
+	if wm.MatchedAt.UnixMicro() != newTime.Truncate(time.Microsecond).UnixMicro() {
+		t.Errorf("MatchedAt = %v, want %v", wm.MatchedAt, newTime)
+	}
+}
+
+func TestAttachExternalRef_PlaceNotFound(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	repo := place.NewRepository(db)
+
+	ref := models.ExternalRef{ID: "wm/999", Confidence: 0.9, MatchedAt: time.Now()}
+	err = repo.AttachExternalRef(ctx, "00000000-0000-0000-0000-000000000000", "wheelmap", ref)
+	if err == nil {
+		t.Error("expected error for non-existent place, got nil")
 	}
 }
 

--- a/internal/place/repository_integration_test.go
+++ b/internal/place/repository_integration_test.go
@@ -9,6 +9,7 @@ package place_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -481,7 +482,10 @@ func TestAttachExternalRef_PlaceNotFound(t *testing.T) {
 	ref := models.ExternalRef{ID: "wm/999", Confidence: 0.9, MatchedAt: time.Now()}
 	err = repo.AttachExternalRef(ctx, "00000000-0000-0000-0000-000000000000", "wheelmap", ref)
 	if err == nil {
-		t.Error("expected error for non-existent place, got nil")
+		t.Fatal("expected error for non-existent place, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `AttachExternalRef` on `place.Repository` using `jsonb_set` for atomic upsert into the `external_ids` JSONB column.
- Compile-time assertion that `*place.Repository` satisfies `identity.AttachRepo` (from #77).
- Integration tests cover empty map / existing different key / existing same key / not-found.

## Test plan
- [x] Unit build + vet clean.
- [x] Integration tests pass via testcontainers PostGIS.
- [x] Re-attaching same source overwrites prior values atomically.
- [x] Not-found returns an error.

Closes #78