### PR TITLE
Wire identity.Resolver into ingestion dispatch

### DIFF
--- a/cmd/ingestion/external_integration_test.go
+++ b/cmd/ingestion/external_integration_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+	"github.com/InWheelOrg/inwheel-api/internal/sources"
+	"github.com/InWheelOrg/inwheel-api/internal/testhelpers"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// syntheticSource is an in-test ExternalFullImporter. The dispatch picks it up
+// via type assertion and routes each emitted Record through identity.Resolver.
+type syntheticSource struct {
+	records []identity.Record
+}
+
+func (s *syntheticSource) Name() string             { return "synthetic" }
+func (s *syntheticSource) Kind() sources.SourceKind { return sources.SourceKindExternal }
+func (s *syntheticSource) FullImport(ctx context.Context, sink sources.RecordSink) error {
+	for _, r := range s.records {
+		if err := sink(ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestExternalIngest_RoutesAllThreeOutcomes(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	seedPlaces := []models.Place{
+		{
+			Name:     "Pascal",
+			Lat:      46.4628,
+			Lng:      6.8417,
+			Category: models.CategoryCafe,
+			Source:   "osm",
+			Status:   models.PlaceStatusActive,
+			Tags: models.PlaceTags{
+				"addr:street":      "Rue du Simplon",
+				"addr:housenumber": "10",
+			},
+			ExternalIDs: models.ExternalIDs{
+				"osm": {ID: "node/100", Confidence: 1.0},
+			},
+		},
+		{
+			Name:     "Lavaux",
+			Lat:      46.462575,
+			Lng:      6.8417,
+			Category: models.CategoryCafe,
+			Source:   "osm",
+			Status:   models.PlaceStatusActive,
+			ExternalIDs: models.ExternalIDs{
+				"osm": {ID: "node/101", Confidence: 1.0},
+			},
+		},
+	}
+	if err := db.Create(&seedPlaces).Error; err != nil {
+		t.Fatalf("seed places: %v", err)
+	}
+
+	records := []identity.Record{
+		{
+			Source: "synthetic", SourceID: "conf-1",
+			Name: "Pascal", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+			Street: "Rue du Simplon", HouseNumber: "10",
+			Payload: json.RawMessage(`{"why":"confident"}`),
+		},
+		{
+			Source: "synthetic", SourceID: "low-1",
+			Name: "Lavaux", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+			Payload: json.RawMessage(`{"why":"low"}`),
+		},
+		{
+			Source: "synthetic", SourceID: "miss-1",
+			Name: "Ghost", Lat: 47.5000, Lng: 7.5000, Category: models.CategoryCafe,
+			Payload: json.RawMessage(`{"why":"miss"}`),
+		},
+	}
+
+	src := &syntheticSource{records: records}
+	if err := runPipeline(ctx, src, "full-import", db); err != nil {
+		t.Fatalf("runPipeline: %v", err)
+	}
+
+	t.Run("confident attaches external ref to matched place", func(t *testing.T) {
+		var got models.Place
+		if err := db.Where("name = ?", "Pascal").First(&got).Error; err != nil {
+			t.Fatalf("lookup Pascal: %v", err)
+		}
+		ref, ok := got.ExternalIDs["synthetic"]
+		if !ok {
+			t.Fatalf("Pascal.external_ids has no 'synthetic' key: %#v", got.ExternalIDs)
+		}
+		if ref.ID != "conf-1" {
+			t.Errorf("ref.ID = %q, want %q", ref.ID, "conf-1")
+		}
+		if ref.Confidence < 0.80 {
+			t.Errorf("ref.Confidence = %v, want >= 0.80 (confident)", ref.Confidence)
+		}
+	})
+
+	t.Run("low-confidence attaches external ref with low confidence", func(t *testing.T) {
+		var got models.Place
+		if err := db.Where("name = ?", "Lavaux").First(&got).Error; err != nil {
+			t.Fatalf("lookup Lavaux: %v", err)
+		}
+		ref, ok := got.ExternalIDs["synthetic"]
+		if !ok {
+			t.Fatalf("Lavaux.external_ids has no 'synthetic' key: %#v", got.ExternalIDs)
+		}
+		if ref.ID != "low-1" {
+			t.Errorf("ref.ID = %q, want %q", ref.ID, "low-1")
+		}
+		if ref.Confidence < 0.55 || ref.Confidence >= 0.80 {
+			t.Errorf("ref.Confidence = %v, want in [0.55, 0.80)", ref.Confidence)
+		}
+	})
+
+	t.Run("no-match enqueues in unmatched_external", func(t *testing.T) {
+		sqlDB, err := db.DB()
+		if err != nil {
+			t.Fatalf("get sql.DB: %v", err)
+		}
+		var count int
+		row := sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+			"synthetic", "miss-1",
+		)
+		if err := row.Scan(&count); err != nil {
+			t.Fatalf("count query: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("unmatched_external row count = %d, want 1", count)
+		}
+	})
+}

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -113,15 +113,19 @@ func runPipeline(ctx context.Context, src sources.Source, command string, gormDB
 	if err := b.flushNow(ctx); err != nil {
 		return fmt.Errorf("final flush: %w", err)
 	}
-	slog.Info("ingestion complete",
-		"source", src.Name(),
-		"command", command,
-		"written", b.written,
-		"confident", counters.confident,
-		"low_confidence", counters.lowConfidence,
-		"no_match", counters.noMatch,
-		"errors", counters.errors,
-	)
+	args := []any{"source", src.Name(), "command", command}
+	switch src.Kind() {
+	case sources.SourceKindCanonical:
+		args = append(args, "written", b.written)
+	case sources.SourceKindExternal:
+		args = append(args,
+			"confident", counters.confident,
+			"low_confidence", counters.lowConfidence,
+			"no_match", counters.noMatch,
+			"errors", counters.errors,
+		)
+	}
+	slog.Info("ingestion complete", args...)
 	return nil
 }
 

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -88,7 +88,7 @@ func run(ctx context.Context, sourceName, command string, cfg config) error {
 	repo := place.NewRepository(gormDB)
 	b := &batcher{size: batchSize, flush: repo.UpsertBatch}
 
-	if err := dispatch(ctx, src, command, b.sink); err != nil {
+	if err := dispatch(ctx, src, command, b.sink, nil); err != nil {
 		return fmt.Errorf("source %q: %w", src.Name(), err)
 	}
 
@@ -104,7 +104,18 @@ func run(ctx context.Context, sourceName, command string, cfg config) error {
 	return nil
 }
 
-func dispatch(ctx context.Context, src sources.Source, command string, sink sources.Sink) error {
+func dispatch(ctx context.Context, src sources.Source, command string, sink sources.Sink, recordSink sources.RecordSink) error {
+	switch src.Kind() {
+	case sources.SourceKindCanonical:
+		return dispatchCanonical(ctx, src, command, sink)
+	case sources.SourceKindExternal:
+		return dispatchExternal(ctx, src, command, recordSink)
+	default:
+		return fmt.Errorf("source %q has unknown kind: %v", src.Name(), src.Kind())
+	}
+}
+
+func dispatchCanonical(ctx context.Context, src sources.Source, command string, sink sources.Sink) error {
 	switch command {
 	case "full-import":
 		fi, ok := src.(sources.FullImporter)
@@ -114,6 +125,25 @@ func dispatch(ctx context.Context, src sources.Source, command string, sink sour
 		return fi.FullImport(ctx, sink)
 	case "diff-sync":
 		ds, ok := src.(sources.DiffSyncer)
+		if !ok {
+			return fmt.Errorf("source %q does not support diff-sync", src.Name())
+		}
+		return ds.DiffSync(ctx, time.Time{}, sink)
+	default:
+		return fmt.Errorf("unknown command: %q", command)
+	}
+}
+
+func dispatchExternal(ctx context.Context, src sources.Source, command string, sink sources.RecordSink) error {
+	switch command {
+	case "full-import":
+		fi, ok := src.(sources.ExternalFullImporter)
+		if !ok {
+			return fmt.Errorf("source %q does not support full-import", src.Name())
+		}
+		return fi.FullImport(ctx, sink)
+	case "diff-sync":
+		ds, ok := src.(sources.ExternalDiffSyncer)
 		if !ok {
 			return fmt.Errorf("source %q does not support diff-sync", src.Name())
 		}

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -12,9 +12,13 @@ import (
 	"os"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/InWheelOrg/inwheel-api/internal/db"
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
 	"github.com/InWheelOrg/inwheel-api/internal/place"
 	"github.com/InWheelOrg/inwheel-api/internal/sources"
+	"github.com/InWheelOrg/inwheel-api/internal/unmatched"
 )
 
 const batchSize = 1000
@@ -69,7 +73,6 @@ func run(ctx context.Context, sourceName, command string, cfg config) error {
 	if err != nil {
 		return err
 	}
-
 	gormDB, err := db.Connect(db.Config{
 		Host:     cfg.DBHost,
 		Port:     cfg.DBPort,
@@ -84,22 +87,40 @@ func run(ctx context.Context, sourceName, command string, cfg config) error {
 	if err := db.Migrate(gormDB); err != nil {
 		return fmt.Errorf("db migrate: %w", err)
 	}
+	return runPipeline(ctx, src, command, gormDB)
+}
 
-	repo := place.NewRepository(gormDB)
-	b := &batcher{size: batchSize, flush: repo.UpsertBatch}
+// runPipeline executes one ingest of src against gormDB. Canonical sources go
+// through the batched upsert path; external sources go through identity.Resolver.
+func runPipeline(ctx context.Context, src sources.Source, command string, gormDB *gorm.DB) error {
+	placesRepo := place.NewRepository(gormDB)
+	unmatchedRepo := unmatched.NewRepository(gormDB)
 
-	if err := dispatch(ctx, src, command, b.sink, nil); err != nil {
+	b := &batcher{size: batchSize, flush: placesRepo.UpsertBatch}
+
+	resolver := &identity.Resolver{
+		Candidates: placesRepo,
+		Places:     placesRepo,
+		Unmatched:  unmatchedRepo,
+		Now:        time.Now,
+	}
+	counters := &resolveCounters{}
+	recordSink := buildRecordSink(resolver, counters)
+
+	if err := dispatch(ctx, src, command, b.sink, recordSink); err != nil {
 		return fmt.Errorf("source %q: %w", src.Name(), err)
 	}
-
 	if err := b.flushNow(ctx); err != nil {
 		return fmt.Errorf("final flush: %w", err)
 	}
-
 	slog.Info("ingestion complete",
 		"source", src.Name(),
 		"command", command,
 		"written", b.written,
+		"confident", counters.confident,
+		"low_confidence", counters.lowConfidence,
+		"no_match", counters.noMatch,
+		"errors", counters.errors,
 	)
 	return nil
 }
@@ -150,5 +171,39 @@ func dispatchExternal(ctx context.Context, src sources.Source, command string, s
 		return ds.DiffSync(ctx, time.Time{}, sink)
 	default:
 		return fmt.Errorf("unknown command: %q", command)
+	}
+}
+
+// resolveCounters tallies external-source outcomes for the run summary.
+type resolveCounters struct {
+	confident     int
+	lowConfidence int
+	noMatch       int
+	errors        int
+}
+
+// buildRecordSink returns a RecordSink that runs resolver on each record,
+// tallies outcomes into counters, and logs but does not abort on per-record errors.
+func buildRecordSink(resolver *identity.Resolver, counters *resolveCounters) sources.RecordSink {
+	return func(ctx context.Context, r identity.Record) error {
+		d, err := resolver.Resolve(ctx, r)
+		if err != nil {
+			counters.errors++
+			slog.Warn("resolve failed",
+				"source", r.Source,
+				"source_id", r.SourceID,
+				"error", err,
+			)
+			return nil
+		}
+		switch d.Kind {
+		case identity.KindConfident:
+			counters.confident++
+		case identity.KindLowConfidence:
+			counters.lowConfidence++
+		case identity.KindNoMatch:
+			counters.noMatch++
+		}
+		return nil
 	}
 }

--- a/internal/sources/osm/source.go
+++ b/internal/sources/osm/source.go
@@ -22,6 +22,8 @@ type Source struct {
 
 func (s *Source) Name() string { return "osm" }
 
+func (s *Source) Kind() sources.SourceKind { return sources.SourceKindCanonical }
+
 func (s *Source) FullImport(ctx context.Context, sink sources.Sink) error {
 	f, err := os.Open(s.PBFPath)
 	if err != nil {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -11,27 +11,56 @@ import (
 	"context"
 	"time"
 
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
 )
 
-// Sink receives one place at a time. The caller decides whether to batch
-// downstream writes.
+// SourceKind discriminates canonical place-registry sources (OSM) from
+// external accessibility sources (Wheelmap etc.) that attach to existing places.
+type SourceKind int
+
+const (
+	// SourceKindCanonical sources own place rows.
+	SourceKindCanonical SourceKind = iota
+	// SourceKindExternal sources contribute external IDs and accessibility
+	// data attached to existing places via identity.Match.
+	SourceKindExternal
+)
+
+// Sink receives one place at a time. Used by canonical sources.
 type Sink func(context.Context, models.Place) error
+
+// RecordSink receives one identity.Record at a time. Used by external sources.
+type RecordSink func(context.Context, identity.Record) error
 
 // Source identifies a place data source.
 type Source interface {
 	// Name returns a stable identifier such as "osm" or "wheelmap".
 	Name() string
+	// Kind returns the pipeline this source belongs to.
+	Kind() SourceKind
 }
 
-// FullImporter performs a complete pull from the source.
+// FullImporter performs a complete pull from a canonical source.
 type FullImporter interface {
 	Source
 	FullImport(ctx context.Context, sink Sink) error
 }
 
-// DiffSyncer pulls changes from the source since the given timestamp.
+// DiffSyncer pulls changes from a canonical source since the given timestamp.
 type DiffSyncer interface {
 	Source
 	DiffSync(ctx context.Context, since time.Time, sink Sink) error
+}
+
+// ExternalFullImporter performs a complete pull from an external source.
+type ExternalFullImporter interface {
+	Source
+	FullImport(ctx context.Context, sink RecordSink) error
+}
+
+// ExternalDiffSyncer pulls changes from an external source since the given timestamp.
+type ExternalDiffSyncer interface {
+	Source
+	DiffSync(ctx context.Context, since time.Time, sink RecordSink) error
 }


### PR DESCRIPTION
## Summary
- Adds `Source.Kind()` (`SourceKindCanonical` / `SourceKindExternal`) and parallel `ExternalFullImporter` / `ExternalDiffSyncer` interfaces with a `RecordSink` that takes `identity.Record`.
- OSM declares `SourceKindCanonical`; canonical pipeline is unchanged.
- New external pipeline: `cmd/ingestion` constructs `identity.Resolver` and an `unmatched.Repository`, builds a `RecordSink` that runs `Resolver.Resolve` per record, tallies outcomes, and logs a summary.
- Per-record errors are logged + counted, not fatal.
- End-to-end integration test: synthetic external source emits three records hitting Confident / LowConfidence / NoMatch, asserts each branch routes correctly through real PostGIS.

## Test plan
- [x] Unit build + vet clean.
- [x] OSM integration test (`TestFullImport_AndorraFixture`) still passes — canonical path unchanged.
- [x] New external integration test (`TestExternalIngest_RoutesAllThreeOutcomes`) covers all three Decision branches end-to-end.

Closes #80, #71