### PR TITLE
Wire retry sweep into canonical ingest

### DIFF
--- a/cmd/ingestion/batcher.go
+++ b/cmd/ingestion/batcher.go
@@ -14,10 +14,11 @@ import (
 // batcher buffers places and flushes in fixed-size batches via flush.
 // It is single-goroutine; cmd/ingestion runs ingestion serially.
 type batcher struct {
-	size    int
-	flush   func(context.Context, []models.Place) error
-	buffer  []models.Place
-	written int
+	size       int
+	flush      func(context.Context, []models.Place) error
+	buffer     []models.Place
+	written    int
+	touchedIDs []string
 }
 
 func (b *batcher) sink(ctx context.Context, p models.Place) error {
@@ -36,6 +37,11 @@ func (b *batcher) flushNow(ctx context.Context) error {
 		return err
 	}
 	b.written += len(b.buffer)
+	for _, p := range b.buffer {
+		if p.ID != "" {
+			b.touchedIDs = append(b.touchedIDs, p.ID)
+		}
+	}
 	b.buffer = b.buffer[:0]
 	return nil
 }

--- a/cmd/ingestion/batcher_test.go
+++ b/cmd/ingestion/batcher_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/InWheelOrg/inwheel-api/pkg/models"
@@ -104,5 +105,44 @@ func TestBatcher_PropagatesFlushError(t *testing.T) {
 	err := b.sink(context.Background(), models.Place{})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("expected sentinel, got %v", err)
+	}
+}
+
+func TestBatcher_TouchedIDsAccumulateAcrossFlushes(t *testing.T) {
+	flushed := [][]models.Place{}
+	b := &batcher{
+		size: 2,
+		flush: func(_ context.Context, ps []models.Place) error {
+			// Simulate UpsertBatch back-populating IDs.
+			for i := range ps {
+				ps[i].ID = fmt.Sprintf("id-%d-%d", len(flushed), i)
+			}
+			cp := make([]models.Place, len(ps))
+			copy(cp, ps)
+			flushed = append(flushed, cp)
+			return nil
+		},
+	}
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		if err := b.sink(ctx, models.Place{Name: fmt.Sprintf("p%d", i)}); err != nil {
+			t.Fatalf("sink: %v", err)
+		}
+	}
+	if err := b.flushNow(ctx); err != nil {
+		t.Fatalf("flushNow: %v", err)
+	}
+	if got := len(b.touchedIDs); got != 5 {
+		t.Errorf("touchedIDs length = %d, want 5", got)
+	}
+	wantIDs := map[string]bool{
+		"id-0-0": true, "id-0-1": true,
+		"id-1-0": true, "id-1-1": true,
+		"id-2-0": true,
+	}
+	for _, id := range b.touchedIDs {
+		if !wantIDs[id] {
+			t.Errorf("unexpected id in touchedIDs: %q", id)
+		}
 	}
 }

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -102,9 +102,11 @@ func runPipeline(ctx context.Context, src sources.Source, command string, gormDB
 	}
 }
 
-// runCanonical drives a canonical source through the batched upsert path.
+// runCanonical drives a canonical source through the batched upsert path,
+// then runs the retry sweep against the IDs of places the batcher touched.
 func runCanonical(ctx context.Context, src sources.Source, command string, gormDB *gorm.DB) error {
 	placesRepo := place.NewRepository(gormDB)
+	unmatchedRepo := unmatched.NewRepository(gormDB)
 	b := &batcher{size: batchSize, flush: placesRepo.UpsertBatch}
 	if err := dispatchCanonical(ctx, src, command, b.sink); err != nil {
 		return fmt.Errorf("source %q: %w", src.Name(), err)
@@ -112,10 +114,31 @@ func runCanonical(ctx context.Context, src sources.Source, command string, gormD
 	if err := b.flushNow(ctx); err != nil {
 		return fmt.Errorf("final flush: %w", err)
 	}
+
+	sweeper := &identity.Sweeper{
+		Candidates: placesRepo,
+		Places:     placesRepo,
+		Queue:      unmatchedRepo,
+		Now:        time.Now,
+	}
+	sweepResult, sweepErr := sweeper.Sweep(ctx, b.touchedIDs)
+	if sweepErr != nil {
+		slog.Warn("sweep failed",
+			"source", src.Name(),
+			"command", command,
+			"error", sweepErr,
+		)
+	}
+
 	slog.Info("ingestion complete",
 		"source", src.Name(),
 		"command", command,
 		"written", b.written,
+		"sweep_considered", sweepResult.Considered,
+		"sweep_confident", sweepResult.Confident,
+		"sweep_low_confidence", sweepResult.LowConfidence,
+		"sweep_no_match", sweepResult.NoMatch,
+		"sweep_errors", sweepResult.Errors,
 	)
 	return nil
 }

--- a/cmd/ingestion/main.go
+++ b/cmd/ingestion/main.go
@@ -130,16 +130,22 @@ func runCanonical(ctx context.Context, src sources.Source, command string, gormD
 		)
 	}
 
-	slog.Info("ingestion complete",
+	args := []any{
 		"source", src.Name(),
 		"command", command,
 		"written", b.written,
-		"sweep_considered", sweepResult.Considered,
-		"sweep_confident", sweepResult.Confident,
-		"sweep_low_confidence", sweepResult.LowConfidence,
-		"sweep_no_match", sweepResult.NoMatch,
-		"sweep_errors", sweepResult.Errors,
-	)
+		"sweep_failed", sweepErr != nil,
+	}
+	if sweepErr == nil {
+		args = append(args,
+			"sweep_considered", sweepResult.Considered,
+			"sweep_confident", sweepResult.Confident,
+			"sweep_low_confidence", sweepResult.LowConfidence,
+			"sweep_no_match", sweepResult.NoMatch,
+			"sweep_errors", sweepResult.Errors,
+		)
+	}
+	slog.Info("ingestion complete", args...)
 	return nil
 }
 

--- a/cmd/ingestion/sweep_integration_test.go
+++ b/cmd/ingestion/sweep_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-api/internal/testhelpers"
+	"github.com/InWheelOrg/inwheel-api/internal/unmatched"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+func TestRetrySweep_DrainsMatchableQueueRowsAfterOSMIngest(t *testing.T) {
+	ctx := context.Background()
+	db, connInfo, cleanup, err := testhelpers.StartPostgresWithConnInfo(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	queueRepo := unmatched.NewRepository(db)
+	clock := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+
+	confidentQueue := models.UnmatchedExternal{
+		Source: "wheelmap", SourceID: "confident-target",
+		Name: "Supermercat Saint Moritz", Category: "shop",
+		Street: "Carretera d'Arinsal", HouseNumber: "16",
+		Lat: 42.571637, Lng: 1.484545,
+		Attempts: 1, LastAttempted: clock,
+		Payload: json.RawMessage(`{"why":"confident"}`),
+	}
+	noMatchQueue := models.UnmatchedExternal{
+		Source: "wheelmap", SourceID: "no-match-target",
+		Name: "Pharmacy Phantom", Category: "healthcare",
+		Lat: 42.571640, Lng: 1.484550,
+		Attempts: 1, LastAttempted: clock,
+		Payload: json.RawMessage(`{"why":"no-match"}`),
+	}
+	untouchedQueue := models.UnmatchedExternal{
+		Source: "wheelmap", SourceID: "untouched-target",
+		Name: "Pacific Phantom", Category: "cafe",
+		Lat: 0.0, Lng: -150.0,
+		Attempts: 3, LastAttempted: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Payload: json.RawMessage(`{"why":"untouched"}`),
+	}
+	for _, u := range []models.UnmatchedExternal{confidentQueue, noMatchQueue, untouchedQueue} {
+		if err := queueRepo.Enqueue(ctx, u); err != nil {
+			t.Fatalf("Enqueue %s: %v", u.SourceID, err)
+		}
+	}
+
+	cfg := config{
+		DBHost:     connInfo.Host,
+		DBPort:     connInfo.Port,
+		DBUser:     connInfo.User,
+		DBPassword: connInfo.Password,
+		DBName:     connInfo.Name,
+		DBSSLMode:  connInfo.SSLMode,
+		OSMPBFPath: fixturePBFPath,
+	}
+	if err := run(ctx, "osm", "full-import", cfg); err != nil {
+		t.Fatalf("OSM run: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+
+	t.Run("confident row deleted and external ref attached to matched place", func(t *testing.T) {
+		var count int
+		if err := sqlDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+			"wheelmap", "confident-target",
+		).Scan(&count); err != nil {
+			t.Fatalf("count confident: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("confident queue row not deleted (count=%d)", count)
+		}
+
+		var place models.Place
+		if err := db.Where("osm_id = ? AND osm_type = ?", int64(521143390), models.OSMNode).First(&place).Error; err != nil {
+			t.Fatalf("lookup place: %v", err)
+		}
+		ref, ok := place.ExternalIDs["wheelmap"]
+		if !ok {
+			t.Fatalf("Supermercat external_ids has no wheelmap key: %#v", place.ExternalIDs)
+		}
+		if ref.ID != "confident-target" {
+			t.Errorf("ref.ID = %q, want %q", ref.ID, "confident-target")
+		}
+		if ref.Confidence < 0.80 {
+			t.Errorf("ref.Confidence = %v, want >= 0.80", ref.Confidence)
+		}
+	})
+
+	t.Run("no-match row's attempts bumped, last_attempted updated", func(t *testing.T) {
+		var attempts int
+		var lastAttempted time.Time
+		if err := sqlDB.QueryRowContext(ctx,
+			"SELECT attempts, last_attempted FROM unmatched_external WHERE source = $1 AND source_id = $2",
+			"wheelmap", "no-match-target",
+		).Scan(&attempts, &lastAttempted); err != nil {
+			t.Fatalf("scan no-match: %v", err)
+		}
+		if attempts != 2 {
+			t.Errorf("no-match attempts = %d, want 2", attempts)
+		}
+		if !lastAttempted.After(clock) {
+			t.Errorf("no-match last_attempted = %v, want after %v", lastAttempted, clock)
+		}
+	})
+
+	t.Run("untouched-region row unchanged", func(t *testing.T) {
+		var attempts int
+		var lastAttempted time.Time
+		if err := sqlDB.QueryRowContext(ctx,
+			"SELECT attempts, last_attempted FROM unmatched_external WHERE source = $1 AND source_id = $2",
+			"wheelmap", "untouched-target",
+		).Scan(&attempts, &lastAttempted); err != nil {
+			t.Fatalf("scan untouched: %v", err)
+		}
+		if attempts != 3 {
+			t.Errorf("untouched attempts = %d, want 3 (unchanged)", attempts)
+		}
+		wantTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		if lastAttempted.UnixMicro() != wantTime.UnixMicro() {
+			t.Errorf("untouched last_attempted = %v, want %v (unchanged)", lastAttempted, wantTime)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Batcher now accumulates IDs of upserted places into `touchedIDs` (GORM back-populates them via `RETURNING id` on the ON CONFLICT upsert).
- `runCanonical` constructs an `identity.Sweeper` and runs it against the touched IDs at the end of every OSM ingest run. Sweep failure is logged but does not fail the run.
- Completion log gains sweep counters: `sweep_considered`, `sweep_confident`, `sweep_low_confidence`, `sweep_no_match`, `sweep_errors`.
- End-to-end integration test pre-populates the queue with three rows (confident, no-match-in-sweep-area, untouched-region), runs the OSM fixture import, and asserts each row routes correctly.

## Test plan
- [x] Unit + integration tests in this PR.
- [x] Existing OSM integration test (`TestFullImport_AndorraFixture`) still passes.
- [x] New sweep integration test (`TestRetrySweep_DrainsMatchableQueueRowsAfterOSMIngest`) covers all three outcomes end-to-end via PostGIS.

Closes #72