### PR TITLE
Resolver enqueues full matchable signal

### DIFF
--- a/cmd/ingestion/external_integration_test.go
+++ b/cmd/ingestion/external_integration_test.go
@@ -90,6 +90,7 @@ func TestExternalIngest_RoutesAllThreeOutcomes(t *testing.T) {
 		{
 			Source: "synthetic", SourceID: "miss-1",
 			Name: "Ghost", Lat: 47.5000, Lng: 7.5000, Category: models.CategoryCafe,
+			Street: "Quai du Léman", HouseNumber: "42",
 			Payload: json.RawMessage(`{"why":"miss"}`),
 		},
 	}
@@ -133,21 +134,37 @@ func TestExternalIngest_RoutesAllThreeOutcomes(t *testing.T) {
 		}
 	})
 
-	t.Run("no-match enqueues in unmatched_external", func(t *testing.T) {
+	t.Run("no-match enqueues in unmatched_external with full matchable signal", func(t *testing.T) {
 		sqlDB, err := db.DB()
 		if err != nil {
 			t.Fatalf("get sql.DB: %v", err)
 		}
-		var count int
+		var (
+			gotName, gotCategory, gotStreet, gotHouse string
+			gotLat, gotLng                            float64
+		)
 		row := sqlDB.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+			`SELECT name, category, street, housenumber, lat, lng
+			 FROM unmatched_external WHERE source = $1 AND source_id = $2`,
 			"synthetic", "miss-1",
 		)
-		if err := row.Scan(&count); err != nil {
-			t.Fatalf("count query: %v", err)
+		if err := row.Scan(&gotName, &gotCategory, &gotStreet, &gotHouse, &gotLat, &gotLng); err != nil {
+			t.Fatalf("scan unmatched row: %v", err)
 		}
-		if count != 1 {
-			t.Errorf("unmatched_external row count = %d, want 1", count)
+		if gotName != "Ghost" {
+			t.Errorf("name = %q, want %q", gotName, "Ghost")
+		}
+		if gotCategory != string(models.CategoryCafe) {
+			t.Errorf("category = %q, want %q", gotCategory, models.CategoryCafe)
+		}
+		if gotStreet != "Quai du Léman" {
+			t.Errorf("street = %q, want %q", gotStreet, "Quai du Léman")
+		}
+		if gotHouse != "42" {
+			t.Errorf("housenumber = %q, want %q", gotHouse, "42")
+		}
+		if gotLat != 47.5000 || gotLng != 7.5000 {
+			t.Errorf("lat/lng = %v/%v, want 47.5/7.5", gotLat, gotLng)
 		}
 	})
 }

--- a/cmd/ingestion/resolver_sweep_roundtrip_integration_test.go
+++ b/cmd/ingestion/resolver_sweep_roundtrip_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+/*
+ * Copyright (C) 2026 InWheel Contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/InWheelOrg/inwheel-api/internal/identity"
+	"github.com/InWheelOrg/inwheel-api/internal/place"
+	"github.com/InWheelOrg/inwheel-api/internal/testhelpers"
+	"github.com/InWheelOrg/inwheel-api/internal/unmatched"
+	"github.com/InWheelOrg/inwheel-api/pkg/models"
+)
+
+// TestResolverEnqueueIsConsumableBySweep proves the Resolver writes queue rows
+// that the Sweeper can actually reconstruct into a Record and match. If
+// Resolver ever drops a matchable column on enqueue, this test fails because
+// the Sweeper rebuilds an empty Record and scores 0 against the seeded place.
+func TestResolverEnqueueIsConsumableBySweep(t *testing.T) {
+	ctx := context.Background()
+	db, cleanup, err := testhelpers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer cleanup()
+
+	placesRepo := place.NewRepository(db)
+	queueRepo := unmatched.NewRepository(db)
+	clock := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
+	resolver := &identity.Resolver{
+		Candidates: placesRepo,
+		Places:     placesRepo,
+		Unmatched:  queueRepo,
+		Now:        func() time.Time { return clock },
+	}
+
+	rec := identity.Record{
+		Source: "synthetic", SourceID: "round-trip-1",
+		Name:        "Pascal",
+		Lat:         46.4628,
+		Lng:         6.8417,
+		Category:    models.CategoryCafe,
+		Street:      "Rue du Simplon",
+		HouseNumber: "10",
+		Payload:     json.RawMessage(`{"why":"no-place-yet"}`),
+	}
+	d, err := resolver.Resolve(ctx, rec)
+	if err != nil {
+		t.Fatalf("Resolve (pre-place): %v", err)
+	}
+	if d.Kind != identity.KindNoMatch {
+		t.Fatalf("Resolve.Kind = %v, want KindNoMatch (no places exist yet)", d.Kind)
+	}
+
+	seed := models.Place{
+		Name:     "Pascal",
+		Lat:      46.4628,
+		Lng:      6.8417,
+		Category: models.CategoryCafe,
+		Source:   "osm",
+		Status:   models.PlaceStatusActive,
+		Tags: models.PlaceTags{
+			"addr:street":      "Rue du Simplon",
+			"addr:housenumber": "10",
+		},
+		ExternalIDs: models.ExternalIDs{
+			"osm": {ID: "node/200", Confidence: 1.0},
+		},
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed place: %v", err)
+	}
+
+	sweeper := &identity.Sweeper{
+		Candidates: placesRepo,
+		Places:     placesRepo,
+		Queue:      queueRepo,
+		Now:        func() time.Time { return clock.Add(time.Hour) },
+	}
+	res, err := sweeper.Sweep(ctx, []string{seed.ID})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if res.Confident != 1 {
+		t.Fatalf("Sweep result = %+v, want Confident=1 (proves the queue row carried full signal)", res)
+	}
+
+	var got models.Place
+	if err := db.First(&got, "id = ?", seed.ID).Error; err != nil {
+		t.Fatalf("reload seeded place: %v", err)
+	}
+	ref, ok := got.ExternalIDs["synthetic"]
+	if !ok {
+		t.Fatalf("seeded place external_ids has no 'synthetic' key: %#v", got.ExternalIDs)
+	}
+	if ref.ID != "round-trip-1" {
+		t.Errorf("ref.ID = %q, want %q", ref.ID, "round-trip-1")
+	}
+	if ref.Confidence < 0.80 {
+		t.Errorf("ref.Confidence = %v, want >= 0.80", ref.Confidence)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	var count int
+	if err := sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM unmatched_external WHERE source = $1 AND source_id = $2",
+		"synthetic", "round-trip-1",
+	).Scan(&count); err != nil {
+		t.Fatalf("count remaining queue rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("queue row not deleted by sweep (count=%d)", count)
+	}
+}

--- a/internal/identity/resolve.go
+++ b/internal/identity/resolve.go
@@ -62,6 +62,10 @@ func (r *Resolver) Resolve(ctx context.Context, rec Record) (Decision, error) {
 		u := models.UnmatchedExternal{
 			Source:        rec.Source,
 			SourceID:      rec.SourceID,
+			Name:          rec.Name,
+			Category:      string(rec.Category),
+			Street:        rec.Street,
+			HouseNumber:   rec.HouseNumber,
 			Lat:           rec.Lat,
 			Lng:           rec.Lng,
 			Payload:       payload,

--- a/internal/identity/resolve_test.go
+++ b/internal/identity/resolve_test.go
@@ -148,6 +148,7 @@ func TestResolve_NoMatchEnqueues(t *testing.T) {
 	rec := identity.Record{
 		Source: "wheelmap", SourceID: "ghost",
 		Name: "Nowhere", Lat: 46.4628, Lng: 6.8417, Category: models.CategoryCafe,
+		Street: "Rue du Simplon", HouseNumber: "10",
 		Payload: payload,
 	}
 	d, err := r.Resolve(context.Background(), rec)
@@ -169,6 +170,18 @@ func TestResolve_NoMatchEnqueues(t *testing.T) {
 	}
 	if got.Lat != 46.4628 || got.Lng != 6.8417 {
 		t.Errorf("enqueued lat/lng = %v/%v, want 46.4628/6.8417", got.Lat, got.Lng)
+	}
+	if got.Name != "Nowhere" {
+		t.Errorf("enqueued Name = %q, want %q", got.Name, "Nowhere")
+	}
+	if got.Category != string(models.CategoryCafe) {
+		t.Errorf("enqueued Category = %q, want %q", got.Category, models.CategoryCafe)
+	}
+	if got.Street != "Rue du Simplon" {
+		t.Errorf("enqueued Street = %q, want %q", got.Street, "Rue du Simplon")
+	}
+	if got.HouseNumber != "10" {
+		t.Errorf("enqueued HouseNumber = %q, want %q", got.HouseNumber, "10")
 	}
 	if string(got.Payload) != string(payload) {
 		t.Errorf("enqueued payload = %s, want %s", got.Payload, payload)


### PR DESCRIPTION
## Summary
- `Resolver.Resolve` was building `UnmatchedExternal` on the no-match branch without `Name`, `Category`, `Street`, or `HouseNumber`. The retry sweep then reconstructed a `Record` with empty signal, scored 0 against every candidate, and the row could never match on a subsequent ingest — defeating the retry-sweep flow for every record produced by the external pipeline in production.
- Populates all four fields from the incoming `Record` on enqueue.
- The integration test in #89 didn't catch this because it seeded queue rows directly via `unmatched.Repository.Enqueue`, bypassing `Resolver`.

## Test plan
- [x] Existing unit `TestResolve_NoMatchEnqueues` extended to assert all matchable columns are populated.
- [x] Existing external-pipeline integration test's no-match assertion extended to read back `name`, `category`, `street`, `housenumber`, `lat`, `lng` from the queue row.
- [x] New round-trip integration test `TestResolverEnqueueIsConsumableBySweep`: runs `Resolve` on a record with no matching place, seeds the place after the fact, runs `Sweep`, asserts the external ref attaches with confidence >= 0.80 and the queue row is gone. Guards future drift between `Resolver`'s write shape and `Sweep`'s read shape.
- [x] `go test ./...` — 254 unit pass.
- [x] `go test -tags integration -timeout 300s ./cmd/ingestion/... ./internal/identity/... ./internal/unmatched/...` — 118 pass.